### PR TITLE
Allow reevaluation of the document

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -330,6 +330,7 @@ x3dom.userAgentFeature = {
             }
         })('load');
     };
+    x3dom.reload = onload
     
     var onunload = function() {
         for (var i=0; i<x3dom.canvases.length; i++) {


### PR DESCRIPTION
I'm currently writing an web application where custom X3D models can be uploaded. Before upload, they can be previewed. For the preview feature I use a Javascript FileReader to read the source and insert the uploaded file as DOM-nodes into the document.

An example (in CoffeeScript)

``` CoffeeScript
    reader = new FileReader();
    reader.onload = (e) =>
      @prepareUpload(e.target.result)

    fileType = 'x3d'
    reader.readAsText(file)

  prepareUpload: (file) ->
      model = $($(file)[2])
      model.attr('width', '300px')
      model.attr('height', '300px')
      model.attr('id', '3dmodel')
      model.prependTo('#preview-area')

      x3dom.reload()
```

Not the most beautiful code, but it illustrates what I want to achieve. Of course the current implementation doesn't pick up the inserted X3D-node, since it only evaluates when the document finished loading.

To display the model I know have exposed the x3dom `onload` function as `x3dom.relod`. This waz I can call `x3dom.reload()` and it will reevaluate the document and actually display the model.

I'm not sure if this is the best way, but it works, so I thought I patch and see what you all think about it.
