### PR TITLE
IndexedFaceSet fix for colorPerVertex option

### DIFF
--- a/src/nodes/Geometry3D.js
+++ b/src/nodes/Geometry3D.js
@@ -2617,8 +2617,10 @@ x3dom.registerNodeType(
 									data.colors =  colors[colorInd[i]];
 								} else if (hasColorInd && !colPerVert) {
 									data.colors =  colors[colorInd[faceCnt]];
-								} else {
+								} else if (colPerVert) {
 									data.colors =  colors[indexes[i]];
+								} else {
+									data.colors =  colors[faceCnt];
 								}
 							}
 							if (hasTexCoord) {


### PR DESCRIPTION
When colorIndex is empty and colorPerVertex is FALSE, colors from Color node should be projected to geometry faces, not to vertices. There should be at least as many colors in the Color node as there are faces in this case.
