### PR TITLE
Fixed crash in Cache.release().

### DIFF
--- a/src/Cache.js
+++ b/src/Cache.js
@@ -182,8 +182,15 @@ x3dom.Cache.prototype.Release = function (gl) {
     for (var texture in this.textures) {
         gl.deleteTexture(this.textures[texture]);
     }
+    this.textures = [];
 
-    for (var shader in this.shaders) {
-        gl.deleteShader(this.shaders[shader]);
+    for (var shaderId in this.shaders) {
+        var shader = this.shaders[shaderId];
+        var glShaders = gl.getAttachedShaders(shader.program);
+        for (var i=0; i<glShaders.length; ++i) {
+            gl.deleteShader(glShaders[i]);
+        }
+         gl.deleteProgram(shader.program)
     }
+    this.shaders = [];
 };

--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -735,6 +735,6 @@ x3dom.Utils.wrapProgram = function (gl, program)
 		loc = gl.getAttribLocation(program, obj.name);
 		shader[obj.name] = loc;
 	}
-	
+	shader["program"]=program;
 	return shader;
 };


### PR DESCRIPTION
This caused a TYPE_ERROR when calling x3dom.reload() because
gl.deleteShader was being called on something other than a WebGLShader.
Our fix was to remove the program associated with each shader and
the GLShaders associated with each program.
