### PR TITLE
Update Utils.js

### DIFF
--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -68,8 +68,6 @@ x3dom.Utils.isNumber = function(n) {
 *****************************************************************************/
 x3dom.Utils.createTexture2D = function(gl, doc, src, bgnd, withCredentials, scale)
 {
-	doc.downloadCount++;
-
 	var texture = gl.createTexture();
     
     //Create a black 1 pixel texture to prevent 'texture not complete' warning
@@ -82,9 +80,14 @@ x3dom.Utils.createTexture2D = function(gl, doc, src, bgnd, withCredentials, scal
     
     texture.ready = false;
 	
+	if (src==null || src=='')
+	  return texture;	
+	
 	var image = new Image();
 	image.crossOrigin = withCredentials ? 'use-credentials' : '';
 	image.src = src;
+	
+	doc.downloadCount++;	
 	
 	image.onload = function() {
         if (scale)


### PR DESCRIPTION
If there is an empty ImageTexture node (its url is empty) in x3d world, doc.downloadCount never decreases to zero in Firefox (image.onload() and/or image.onerror() does not get called). This means that progressDiv is still visible. Fix for this is obvious -- doc.downloadCount is not increased in x3dom.Utils.createTexture2D() if url is empty and texture is immediately returned instead. Solution tested in x3dom 1.5.1 only.
