### PR TITLE
UTM support for Geospatial

### DIFF
--- a/src/nodes/Geospatial.js
+++ b/src/nodes/Geospatial.js
@@ -208,8 +208,11 @@ x3dom.registerNodeType(
                 var clat = Math.cos(source_lat);
 
                 /* square root approximation for Rn */
-                var Rn = A / ( (0.25 - Eps25 * slat2 + 0.9999944354799/4.0) + 
-                         (0.25-Eps25 * slat2)/(0.25 - Eps25 * slat2 + 0.9999944354799/4.0));
+                /* var Rn = A / ( (0.25 - Eps25 * slat2 + 0.9999944354799/4.0) + 
+                         (0.25-Eps25 * slat2)/(0.25 - Eps25 * slat2 + 0.9999944354799/4.0)); */
+
+                // Rn with sqrt; really much slower ? http://www.epsg.org/guides/docs/g7-2.pdf p.94
+                var Rn = A / Math.sqrt(1.0 - Eps2 * slat2);
 
                 var RnPh = Rn + coords[i].z;
                 


### PR DESCRIPTION
This set of changes adds UTM coordinate support for the Geospatial component. It uses the Proj4js 1.1.0 library.
