### PR TITLE
Corrected the initial paramters of the Volume Rendering demo

### DIFF
--- a/example/x3dom_volrenOpacityTestTF_aorta.xhtml
+++ b/example/x3dom_volrenOpacityTestTF_aorta.xhtml
@@ -19,7 +19,7 @@
             <VolumeData id='volume' dimensions='4.0 4.0 4.0'>
               <ImageTextureAtlas containerField='voxels' url='volume/aorta4096.png'
                                  numberOfSlices='96' slicesOverX='10' slicesOverY='10'/>
-              <OpacityMapVolumeStyle lightFactor='0.02' opacityFactor='0.4'>
+              <OpacityMapVolumeStyle lightFactor='1.2' opacityFactor='6.0'>
                 <ImageTexture containerField='transferFunction' url='volume/transfer.png'/>
               </OpacityMapVolumeStyle>
             </VolumeData>


### PR DESCRIPTION
The default values for the OpacityMapVolumeStyle changed on the last pull requests for the Volume Rendering component, this pull request fixes the main demo.
