### PR TITLE
UTM builtin support

### DIFF
--- a/src/nodes/Geospatial.js
+++ b/src/nodes/Geospatial.js
@@ -245,8 +245,13 @@ x3dom.registerNodeType(
                 var clat = Math.cos(source_lat);
 
                 /* square root approximation for Rn */
+                /* replaced by real sqrt
                 var Rn = A / ( (0.25 - Eps25 * slat2 + 0.9999944354799/4.0) + 
-                         (0.25-Eps25 * slat2)/(0.25 - Eps25 * slat2 + 0.9999944354799/4.0));
+                        (0.25-Eps25 * slat2)/(0.25 - Eps25 * slat2 + 0.9999944354799/4.0));
+                */
+
+                // with real sqrt; really slower ?
+                var Rn = A / Math.sqrt(1.0 - Eps2 * slat2);
 
                 var RnPh = Rn + coords[i].z;
                 


### PR DESCRIPTION
This branch adds UTM support for geoCoordinates to Geospatial.js by implementing UTMtoGC with the math for inverse transverse Mercator projection based on S. Dutch's, UWGB, javascript code (https://www.uwgb.edu/dutchs/UsefulData/ConvertUTMNoOZ.HTM) and then using the existing GDtoGC function to compute the desired geocentric WGS84 coordinates.
