### PR TITLE
Geospatial work: implemented GeoLocation node

### DIFF
--- a/src/nodes/Geospatial.js
+++ b/src/nodes/Geospatial.js
@@ -640,61 +640,60 @@ x3dom.registerNodeType(
             this.addField_SFNode('geoOrigin', x3dom.nodeTypes.X3DChildNode);
 
             // similar to what transform in Grouping.js does
-            var coords = new x3dom.fields.MFVec3f();
-            coords.push(this._vf.geoCoords);
-            // x3dom.debug.logError(coords);
+            var position = this._vf.geoCoords;
             var geoSystem = this._vf.geoSystem;
-            // x3dom.debug.logError(geoSystem);
             var geoOrigin = this._cf.geoOrigin;
-            // x3dom.debug.logError(geoOrigin);
-            var transformed = x3dom.nodeTypes.GeoCoordinate.prototype.GEOtoX3D(geoSystem, geoOrigin, coords);
-
-            //2 rotations to get required orientation
-            //Up (Y) to skywards, and depth (-Z) to North
-            //1) around X to point up by
-            //angle between Z and new up plus 90
-            //(angle between Z and orig. up)
-            //2) around Z to get orig. up on longitude
-
-            var newUp = transformed[0].normalize();     
-            var Xaxis = new  x3dom.fields.SFVec3f(1,0,0);
-            // below uses geocentric latitude but only geodetic latitude would give exact tangential plane
-            // http://info.ogp.org.uk/geodesy/guides/docs/G7-2.pdf
-            // has formulas for deriving geodetic latitude, eg a GCtoGD function
-            var rotlat = Math.PI - Math.asin(newUp.z); // latitude as asin of z; only valid for spheres
-            // x3dom.debug.logError(rotlat * 180/Math.PI);
-            var rotUpQuat = new x3dom.fields.Quaternion.axisAngle(Xaxis, rotlat);
-            // x3dom.debug.logError(rotUpQuat);
-            var rotlon = Math.PI/2 + Math.atan2(newUp.y, newUp.x); // 90 to get to prime meridian; atan2 gets the sign correct for longitude; is exact since in circular section
-            // x3dom.debug.logError("rotlon: "+rotlon*180/Math.PI);
-            var Zaxis = new x3dom.fields.SFVec3f(0,0,1);
-            var rotZQuat = new x3dom.fields.Quaternion.axisAngle(Zaxis, rotlon);
-            //var rotMatrix = rotQuat.toMatrix(); 
-            //this._trafo =  x3dom.fields.SFMatrix4f.translation(transformed[0]).mult(rotZQuat.toMatrix()).mult(rotUpQuat.toMatrix());
-            this._trafo = x3dom.fields.SFMatrix4f.translation(transformed[0]).mult(rotZQuat.multiply(rotUpQuat).toMatrix());
+            
+	    this._trafo =  this.getGeoTransRotMat(geoSystem, geoOrigin, position);
         },
         {
+	    getGeoRotMat: function (positionGC)
+            {
+                //returns transformation matrix to align coordinate system with geoposition as required:
+                //2 rotations to get required orientation
+                //Up (Y) to skywards, and depth (-Z) to North
+                //1) around X to point up by
+                //angle between Z and new up plus 90
+                //(angle between Z and orig. up)
+                //2) around Z to get orig. up on longitude
+              
+                var newUp = positionGC.normalize();     
+                var Xaxis = new  x3dom.fields.SFVec3f(1,0,0);
+                // below uses geocentric latitude but only geodetic latitude would give exact tangential plane
+                // http://info.ogp.org.uk/geodesy/guides/docs/G7-2.pdf
+                // has formulas for deriving geodetic latitude, eg a GCtoGD function
+             
+                var rotlat = Math.PI - Math.asin(newUp.z); // latitude as asin of z; only valid for spheres
+                var rotUpQuat = new x3dom.fields.Quaternion.axisAngle(Xaxis, rotlat);
+                var rotlon = Math.PI/2 + Math.atan2(newUp.y, newUp.x);// 90 to get to prime meridian; atan2 gets the sign correct for longitude; is exact since in circular section
+                var Zaxis = new x3dom.fields.SFVec3f(0,0,1);
+                var rotZQuat = new x3dom.fields.Quaternion.axisAngle(Zaxis, rotlon);
+                //return rotZQuat.toMatrix().mult(rotUpQuat.toMatrix();
+                return rotZQuat.multiply(rotUpQuat).toMatrix();
+                
+            },
+            getGeoTransRotMat: function (geoSystem, geoOrigin, position)
+            {
+                //accept geocoords, returntranslation/rotation transform matrix
+		var coords = new x3dom.fields.MFVec3f();
+                coords.push(position);
+                    
+                var transformed = x3dom.nodeTypes.GeoCoordinate.prototype.GEOtoX3D(geoSystem, geoOrigin, coords)[0];
+                var rotMat = this.getGeoRotMat(transformed);
+                return x3dom.fields.SFMatrix4f.translation(transformed).mult(rotMat);
+                
+            },
             //mimic what transform node does
             fieldChanged: function (fieldName)
             {
                 if (fieldName == "geoSystem" || fieldName == "geoCoords" ||
                     fieldName == "geoOrigin")
                 {
-                    
-                    var coords = new x3dom.fields.MFVec3f();
-                    coords.push(this._vf.geoCoords);
-                    var geoSystem = this._vf.geoSystem;
+                    var position = this._vf.geoCoords;
+		    var geoSystem = this._vf.geoSystem;
                     var geoOrigin = this._cf.geoOrigin;
-                    var transformed = x3dom.nodeTypes.GeoCoordinate.prototype.GEOtoX3D(geoSystem, geoOrigin, coords);
-                    var newUp = transformed[0].normalize();     
-                    var Xaxis = new  x3dom.fields.SFVec3f(1,0,0);
-                    var rotlat = Math.PI - Math.asin(newUp.z); 
-                    var rotUpQuat = new x3dom.fields.Quaternion.axisAngle(Xaxis, rotlat);
-                    var rotlon = Math.PI/2 + Math.atan2(newUp.y, newUp.x);
-                    var Zaxis = new x3dom.fields.SFVec3f(0,0,1);
-                    var rotZQuat = new x3dom.fields.Quaternion.axisAngle(Zaxis, rotlon);
-                    this._trafo =  x3dom.fields.SFMatrix4f.translation(transformed[0]).mult(rotZQuat.toMatrix()).mult(rotUpQuat.toMatrix());
-
+		    this._trafo =  this.getGeoTransRotMat(geoSystem, geoOrigin, position);
+          
                     this.invalidateVolume();
                     //this.invalidateCache();
                 }


### PR DESCRIPTION
This adds support for the GeoLocation node in Geospatial.js

One caveat is that the node derives from X3DTransformNode and not from X3DGroupingNode as implied by the spec.
However, the GeoLocation functionality is in effect a specialized Transform node.

Here are two examples which show the use of the node:

https://googledrive.com/host/0BwIhFzkLaQ9XOFd2ZFlTNnAyMkE/A4_GeoLocation.html
https://googledrive.com/host/0BwIhFzkLaQ9XOFd2ZFlTNnAyMkE/GeospatialCoordinateAxesNsewExample_updated.html
