### PR TITLE
Moved fog application to the correct place

### DIFF
--- a/src/shader/ShaderDynamic.js
+++ b/src/shader/ShaderDynamic.js
@@ -717,12 +717,6 @@ x3dom.shader.DynamicShader.prototype.generateFragmentShader = function(gl, prope
 		}
 	}
 	
-	//Fog
-	if(properties.FOG){
-		shader += "float f0 = calcFog(fragEyePosition);\n";
-		shader += "color.rgb = fogColor * (1.0-f0) + f0 * (color.rgb);\n";
-	}
-	
 	//Kill pixel
 	if(properties.TEXT) {
 		shader += "if (color.a <= 0.5) discard;\n";
@@ -732,7 +726,15 @@ x3dom.shader.DynamicShader.prototype.generateFragmentShader = function(gl, prope
 
     //Output the gamma encoded result.
     shader += "color = clamp(color, 0.0, 1.0);\n";
-    shader += "gl_FragColor = " + x3dom.shader.encodeGamma(properties, "color") + ";\n";
+    shader += "color = " + x3dom.shader.encodeGamma(properties, "color") + ";\n";
+	
+	//Fog
+	if(properties.FOG){
+		shader += "float f0 = calcFog(fragEyePosition);\n";
+		shader += "color.rgb = fogColor * (1.0-f0) + f0 * (color.rgb);\n";
+	}
+	
+    shader += "gl_FragColor = color;\n";
 	
 	//End Of Shader
 	shader += "}\n";


### PR DESCRIPTION
The fog was applied before gamma encoding, resulting in incorrect blending with fog color other than white. To see the difference, set the background skycolor and fog color to the same non-white color. One should expect the objects to dissapear in the sky as they get far.
