### PR TITLE
increase X3D compliance: don't encode urls at sight.

### DIFF
--- a/src/nodes/Geometry3D/ExternalGeometry.js
+++ b/src/nodes/Geometry3D/ExternalGeometry.js
@@ -81,14 +81,14 @@ x3dom.registerNodeType(
                 //post request
                 xhr = new XMLHttpRequest();
 
-                xhr.open("GET", encodeURI(this._vf['url']), true);
+                xhr.open("GET", this._vf['url'], true);
 
                 xhr.responseType = "arraybuffer";
 
                 xhr.send(null);
 
                 xhr.onerror = function() {
-                    x3dom.debug.logError("Unable to load SRC data from URL \"" + encodeURI(that._vf['url']) + "\"");
+                    x3dom.debug.logError("Unable to load SRC data from URL \"" + that._vf['url'] + "\"");
                 };
 
                 //TODO: currently, we assume that the referenced file is always an SRC file
@@ -131,13 +131,13 @@ x3dom.registerNodeType(
                         else
                         {
                             x3dom.debug.logError("Invalid SRC data, loaded from URL \"" +
-                                                 encodeURI(that._vf['url']) + "\"");
+                                                 that._vf['url'] + "\"");
                             return;
                         }
                     }
                     else
                     {
-                        x3dom.debug.logError("Unable to load SRC data from URL \"" + encodeURI(that._vf['url']) + "\"");
+                        x3dom.debug.logError("Unable to load SRC data from URL \"" + that._vf['url'] + "\"");
                     }
                 };
             } ,

--- a/src/nodes/Grouping/Scene.js
+++ b/src/nodes/Grouping/Scene.js
@@ -113,7 +113,7 @@ x3dom.registerNodeType(
                 var that = this;
                 var xhr = new XMLHttpRequest();
 
-                xhr.open("GET", encodeURI(this._nameSpace.getURL(this._vf.shadowObjectIdMapping)), true);
+                xhr.open("GET", this._nameSpace.getURL(this._vf.shadowObjectIdMapping), true);
                 xhr.send();
 
                 xhr.onload = function()

--- a/src/nodes/Networking/Inline.js
+++ b/src/nodes/Networking/Inline.js
@@ -299,15 +299,6 @@ x3dom.registerNodeType(
                 {
                     var xhrURI = this._nameSpace.getURL(this._vf.url[0]);
 
-                    //Unfortunately, there is currently an inconsistent behavior between
-                    //chrome and firefox, where the first one is "escaping" the "%" character in the
-                    //blob URI, which contains a ref to a "file" object. This can also not be fixed by
-                    //first using "decodeURI", because, in that case, "%3A" is not resolved to "%".
-                    if (!(xhrURI.substr(0, 5) === "blob:"))
-                    {
-                        xhrURI = encodeURI(xhrURI);
-                    }
-
                     xhr.open('GET', xhrURI, true);
 
                     this._nameSpace.doc.downloadCount += 1;

--- a/src/nodes/Networking/MultiPart.js
+++ b/src/nodes/Networking/MultiPart.js
@@ -902,15 +902,6 @@ x3dom.registerNodeType(
                 {
                     var xhrURI = this._nameSpace.getURL(this._vf.url[0]);
 
-                    //Unfortunately, there is currently an inconsistent behavior between
-                    //chrome and firefox, where the first one is "escaping" the "%" character in the
-                    //blob URI, which contains a ref to a "file" object. This can also not be fixed by
-                    //first using "decodeURI", because, in that case, "%3A" is not resolved to "%".
-                    if (!(xhrURI.substr(0, 5) === "blob:"))
-                    {
-                        xhrURI = encodeURI(xhrURI);
-                    }
-
                     xhr.open('GET', xhrURI, true);
 
                     this._nameSpace.doc.downloadCount += 1;

--- a/src/nodes/Shaders/ShaderPart.js
+++ b/src/nodes/Shaders/ShaderPart.js
@@ -70,7 +70,7 @@ x3dom.registerNodeType(
                     if (that._vf.url.length && that._vf.url[0].indexOf('\n') == -1)
                     {
                         var xhr = new XMLHttpRequest();
-                        xhr.open("GET", encodeURI(that._nameSpace.getURL(that._vf.url[0])), false);
+                        xhr.open("GET", that._nameSpace.getURL(that._vf.url[0]), false);
                         xhr.onload = function() {
                             that._vf.url = new x3dom.fields.MFString( [] );
                             that._vf.url.push(xhr.response);

--- a/src/util/BinaryContainerSetup.js
+++ b/src/util/BinaryContainerSetup.js
@@ -341,7 +341,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (binGeo._vf.index.length > 0)
     {
         var xmlhttp0 = new XMLHttpRequest();
-        xmlhttp0.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.index)), true);
+        xmlhttp0.open("GET", shape._nameSpace.getURL(binGeo._vf.index), true);
         xmlhttp0.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;
@@ -415,7 +415,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (binGeo._hasStrideOffset && binGeo._vf.coord.length > 0)
     {
         var xmlhttp = new XMLHttpRequest();
-        xmlhttp.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.coord)), true);
+        xmlhttp.open("GET", shape._nameSpace.getURL(binGeo._vf.coord), true);
         xmlhttp.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;
@@ -525,7 +525,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (!binGeo._hasStrideOffset && binGeo._vf.coord.length > 0)
     {
         var xmlhttp1 = new XMLHttpRequest();
-        xmlhttp1.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.coord)), true);
+        xmlhttp1.open("GET", shape._nameSpace.getURL(binGeo._vf.coord), true);
         xmlhttp1.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;
@@ -621,7 +621,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (!binGeo._hasStrideOffset && binGeo._vf.normal.length > 0)
     {
         var xmlhttp2 = new XMLHttpRequest();
-        xmlhttp2.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.normal)), true);
+        xmlhttp2.open("GET", shape._nameSpace.getURL(binGeo._vf.normal), true);
         xmlhttp2.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;
@@ -678,7 +678,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (!binGeo._hasStrideOffset && binGeo._vf.texCoord.length > 0)
     {
         var xmlhttp3 = new XMLHttpRequest();
-        xmlhttp3.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.texCoord)), true);
+        xmlhttp3.open("GET", shape._nameSpace.getURL(binGeo._vf.texCoord), true);
         xmlhttp3.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;
@@ -767,7 +767,7 @@ x3dom.BinaryContainerLoader.setupBinGeo = function(shape, sp, gl, viewarea, curr
     if (!binGeo._hasStrideOffset && binGeo._vf.color.length > 0)
     {
         var xmlhttp4 = new XMLHttpRequest();
-        xmlhttp4.open("GET", encodeURI(shape._nameSpace.getURL(binGeo._vf.color)), true);
+        xmlhttp4.open("GET", shape._nameSpace.getURL(binGeo._vf.color), true);
         xmlhttp4.responseType = "arraybuffer";
 
         shape._nameSpace.doc.downloadCount += 1;


### PR DESCRIPTION
This seems superfluous to begin with. encodeURI() is neither
idempotent nor in any way sensible to do without specific reason. To
wit, jquery, the likely most sophisticated wrapper aroud XHR, simply
never calls encodeURI() anywhere whatsoever. I would support
force-breaking the build on occurrence - in generic code, this is
almost always concealing other problems.

I have not looked at possible changes to error handling, as some
errors might occur earlier which have previously been hidden by this
behaviour. However my cases (that can't work without this) do work. It
is ultimatly a user problem if the url is not an url, and  perhaps that
should be signaled clearly when setting the field.
