### PR TITLE
Don' use Number.MIN_VALUE for Vec3f.MIN

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -1564,7 +1564,7 @@ x3dom.fields.SFVec3f.copy = function(v) {
 };
 
 x3dom.fields.SFVec3f.MIN = function() {
-    return new x3dom.fields.SFVec3f(Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE);
+    return new x3dom.fields.SFVec3f(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
 };
 
 x3dom.fields.SFVec3f.MAX = function() {


### PR DESCRIPTION
I'm not 100% sure about his one, but I stumbled on it trying to make sense of the LOD changes. 

From Mozilla: "The Number.MIN_VALUE property represents the smallest
positive numeric value representable in JavaScript.

The MIN_VALUE property is the number closest to 0, not the most
negative number, that JavaScript can represent.

MIN_VALUE has a value of approximately 5e-324. Values smaller than
MIN_VALUE ("underflow values") are converted to 0."

This means: x>= MIN_VALUE == x > 0 for all x

and is almost never what one wanted it to mean. Vec3f.MIN
is used exclusively for getVolume()-related things which
suports that this is indeed -MAX_VALUE that is expected.

Signed-off-by: Simon Thum simon.thum@igd.fraunhofer.de
