### PR TITLE
Consider if a light is defined before defining the light equation

### DIFF
--- a/src/nodes/VolumeRendering/X3DVolumeRenderStyleNode.js
+++ b/src/nodes/VolumeRendering/X3DVolumeRenderStyleNode.js
@@ -65,43 +65,47 @@ x3dom.registerNodeType(
 
             // default light equation to be overwritten by concrete render style
             lightEquationShaderText: function(){
-                return "void lighting(in float lType, in vec3 lLocation, in vec3 lDirection, in vec3 lColor, in vec3 lAttenuation, " + 
-                "in float lRadius, in float lIntensity, in float lAmbientIntensity, in float lBeamWidth, " +
-                "in float lCutOffAngle, in vec3 N, in vec3 V, inout vec3 ambient, inout vec3 diffuse, " +
-                "inout vec3 specular)\n" +
-                "{\n" +
-                "   vec3 L;\n" +
-                "   float spot = 1.0, attentuation = 0.0;\n" +
-                "   if(lType == 0.0) {\n" +
-                "       L = -normalize(lDirection);\n" +
-                "       V = normalize(V);\n" +
-                "       attentuation = 1.0;\n" +
-                "   } else{\n" +
-                "       L = (lLocation - (-V));\n" +
-                "       float d = length(L);\n" +
-                "       L = normalize(L);\n" +
-                "       V = normalize(V);\n" +
-                "       if(lRadius == 0.0 || d <= lRadius) {\n" +
-                "           attentuation = 1.0 / max(lAttenuation.x + lAttenuation.y * d + lAttenuation.z * (d * d), 1.0);\n" +
-                "       }\n" +
-                "       if(lType == 2.0) {\n" +
-                "           float spotAngle = acos(max(0.0, dot(-L, normalize(lDirection))));\n" +
-                "           if(spotAngle >= lCutOffAngle) spot = 0.0;\n" +
-                "           else if(spotAngle <= lBeamWidth) spot = 1.0;\n" +
-                "           else spot = (spotAngle - lCutOffAngle ) / (lBeamWidth - lCutOffAngle);\n" +
-                "       }\n" +
-                "   }\n" +
-                "   vec3  H = normalize( L + V );\n" +
-                "   float NdotL = max(0.0, dot(L, N));\n" +
-                "   float NdotH = max(0.0, dot(H, N));\n" +   
-                "   float ambientFactor  = lAmbientIntensity;\n" +
-                "   float diffuseFactor  = lIntensity * NdotL;\n" +
-                "   float specularFactor = lIntensity * pow(NdotH,128.0);\n" +
-                "   ambient  += lColor * ambientFactor * attentuation * spot;\n" +
-                "   diffuse  += lColor * diffuseFactor * attentuation * spot;\n" +
-                "   specular += lColor * specularFactor * attentuation * spot;\n" +  
-                "}\n"+
-                "\n"
+                if (x3dom.nodeTypes.X3DLightNode.lightID>0){
+                    return "void lighting(in float lType, in vec3 lLocation, in vec3 lDirection, in vec3 lColor, in vec3 lAttenuation, " + 
+                    "in float lRadius, in float lIntensity, in float lAmbientIntensity, in float lBeamWidth, " +
+                    "in float lCutOffAngle, in vec3 N, in vec3 V, inout vec3 ambient, inout vec3 diffuse, " +
+                    "inout vec3 specular)\n" +
+                    "{\n" +
+                    "   vec3 L;\n" +
+                    "   float spot = 1.0, attentuation = 0.0;\n" +
+                    "   if(lType == 0.0) {\n" +
+                    "       L = -normalize(lDirection);\n" +
+                    "       V = normalize(V);\n" +
+                    "       attentuation = 1.0;\n" +
+                    "   } else{\n" +
+                    "       L = (lLocation - (-V));\n" +
+                    "       float d = length(L);\n" +
+                    "       L = normalize(L);\n" +
+                    "       V = normalize(V);\n" +
+                    "       if(lRadius == 0.0 || d <= lRadius) {\n" +
+                    "           attentuation = 1.0 / max(lAttenuation.x + lAttenuation.y * d + lAttenuation.z * (d * d), 1.0);\n" +
+                    "       }\n" +
+                    "       if(lType == 2.0) {\n" +
+                    "           float spotAngle = acos(max(0.0, dot(-L, normalize(lDirection))));\n" +
+                    "           if(spotAngle >= lCutOffAngle) spot = 0.0;\n" +
+                    "           else if(spotAngle <= lBeamWidth) spot = 1.0;\n" +
+                    "           else spot = (spotAngle - lCutOffAngle ) / (lBeamWidth - lCutOffAngle);\n" +
+                    "       }\n" +
+                    "   }\n" +
+                    "   vec3  H = normalize( L + V );\n" +
+                    "   float NdotL = max(0.0, dot(L, N));\n" +
+                    "   float NdotH = max(0.0, dot(H, N));\n" +   
+                    "   float ambientFactor  = lAmbientIntensity;\n" +
+                    "   float diffuseFactor  = lIntensity * NdotL;\n" +
+                    "   float specularFactor = lIntensity * pow(NdotH,128.0);\n" +
+                    "   ambient  += lColor * ambientFactor * attentuation * spot;\n" +
+                    "   diffuse  += lColor * diffuseFactor * attentuation * spot;\n" +
+                    "   specular += lColor * specularFactor * attentuation * spot;\n" +  
+                    "}\n"+
+                    "\n";
+                }else{
+                    return "";
+                }
             },
         }
     )


### PR DESCRIPTION
Little fix, the light equation is only needed on the shader, when a light has been defined on the scene.
