### PR TITLE
Fix db click checking

### DIFF
--- a/src/Viewarea.js
+++ b/src/Viewarea.js
@@ -1552,7 +1552,7 @@ x3dom.Viewarea.prototype.onMouseOut = function (x, y, buttonState)
 
 x3dom.Viewarea.prototype.onDoubleClick = function (x, y)
 {
-    if (this._doc._x3dElem.hasAttribute() &&
+    if (this._doc._x3dElem.hasAttribute('disableDoubleClick') &&
         this._doc._x3dElem.getAttribute('disableDoubleClick') === 'true') {
         return;
     }


### PR DESCRIPTION
Fixed the check for enabled double-click, with the correct number of parameters on getAttribute as pointed out by @mlimper and @yjung
