### PR TITLE
fix mouse up on chrome ( mac and windows touch)

### DIFF
--- a/src/nodes/Networking/MultiPart.js
+++ b/src/nodes/Networking/MultiPart.js
@@ -186,7 +186,7 @@ x3dom.registerNodeType(
                         }
 
                         //if some mouse button is up fire mouseup event
-                        if (this._lastButton != 0 && e.button == 0) {
+                        if (e.mouseup || (this._lastButton != 0 && e.button == 0)) {
                             e.type = "mouseup";
                             this.callEvtHandler("onmouseup", e);
                             this._lastButton = 0;


### PR DESCRIPTION
mouse up is recognized by an additional mouse move event with button=0,
but it seems like this event is not fired on mac or on touch input. mouse up wont be recognized until the next event.
checking for the mouse up flag fixes this.
