### PR TITLE
fixed new quaternion w/o parameters

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -1747,8 +1747,8 @@ x3dom.fields.Quaternion = function(x, y, z, w) {
     if (arguments.length === 0) {
         this.x = 0;
         this.y = 0;
-        this.z = 1;
-        this.w = 0;
+        this.z = 0;
+        this.w = 1;
     }
     else {
         this.x = x;


### PR DESCRIPTION
new quaternion was internally set to 0,0,1,0 which are the default values for an sfrotation (no rotation at all), but represent a rotation in the quaternion representation
