### PR TITLE
ElevationGrid: improved TextureCoordinateGenerator support 

### DIFF
--- a/src/nodes/Geometry3DExt/ElevationGrid.js
+++ b/src/nodes/Geometry3DExt/ElevationGrid.js
@@ -196,7 +196,8 @@ x3dom.registerNodeType(
                 }
 
                 var numTexComponents = 2;
-
+                var texMode;
+                
                 var texCoordNode = this._cf.texCoord.node;
                 if (x3dom.isa(texCoordNode, x3dom.nodeTypes.MultiTextureCoordinate)) {
                     if (texCoordNode._cf.texCoord.nodes.length)
@@ -210,6 +211,11 @@ x3dom.registerNodeType(
                             numTexComponents = 3;
                         }
                     }
+                    
+                    else if (texCoordNode._vf.mode) {
+                        texMode = texCoordNode._vf.mode;
+                    }
+                    //check for _vf.mode in case of TextureCoordinateGenerator
                 }
 
                 var numColComponents = 3;
@@ -246,6 +252,7 @@ x3dom.registerNodeType(
                                 this._mesh._texCoords[0].push(texCoords[c].z);
                             }
                         }
+                        
                         else {
                             this._mesh._texCoords[0].push(x / subx);
                             this._mesh._texCoords[0].push(y / suby);
@@ -265,7 +272,9 @@ x3dom.registerNodeType(
                         c++;
                     }
                 }
-
+                
+                if (texMode) {this._mesh.calcTexCoords(texMode);}
+                        
                 for (y = 1; y <= suby; y++) {
                     for (x = 0; x < subx; x++) {
                         this._mesh._indices[0].push((y - 1) * (subx + 1) + x);

--- a/src/nodes/Geometry3DExt/ElevationGrid.js
+++ b/src/nodes/Geometry3DExt/ElevationGrid.js
@@ -215,7 +215,6 @@ x3dom.registerNodeType(
                     else if (texCoordNode._vf.mode) {
                         texMode = texCoordNode._vf.mode;
                     }
-                    //check for _vf.mode in case of TextureCoordinateGenerator
                 }
 
                 var numColComponents = 3;

--- a/src/nodes/Geometry3DExt/ElevationGrid.js
+++ b/src/nodes/Geometry3DExt/ElevationGrid.js
@@ -273,8 +273,6 @@ x3dom.registerNodeType(
                     }
                 }
                 
-                if (texMode) {this._mesh.calcTexCoords(texMode);}
-                        
                 for (y = 1; y <= suby; y++) {
                     for (x = 0; x < subx; x++) {
                         this._mesh._indices[0].push((y - 1) * (subx + 1) + x);
@@ -293,6 +291,8 @@ x3dom.registerNodeType(
                 if (!normals)
                     this._mesh.calcNormals(Math.PI, this._vf.ccw);
 
+                if (texMode) {this._mesh.calcTexCoords(texMode);}
+                
                 this.invalidateVolume();
                 this._mesh._numTexComponents = numTexComponents;
                 this._mesh._numColComponents = numColComponents;


### PR DESCRIPTION
SPHERE-LOCAL mode (and other modes when implemented) supported by calling _mesh.calcTexCoords(), in the same way as other mesh generating nodes such as IndexedFaceSet.

When both TextureCoordinate and TextureCoordinateGenerator nodes are provided, TextureCoordinateGenerator may take precedence. Not sure what the spec. suggests for this case.

Here is a scene which uses SPHERE-LOCAL mode with the patch:

http://andreasplesch.github.io/x3dom/GeoElevationGrid_texture/terrain_sphere-local.xhtml