### PR TITLE
SFImage.copy function bug

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -2469,7 +2469,9 @@ x3dom.fields.SFImage.copy = function(that) {
     destination.width = that.width;
     destination.height = that.height;
     destination.comp = that.comp;
-    destination.setPixels(that.array);
+    //use instead slice?
+    //destination.array = that.array.slice();
+    destination.setPixels(that.getPixels());
     return destination;
 };
 


### PR DESCRIPTION
The .setPixels() expects a pixels array, but the image array was provided.
Instead of converting to and from Pixels, it may be possible to just copy the array using the slice method  ?