### PR TITLE
improve text fontstyle support

### DIFF
--- a/src/Texture.js
+++ b/src/Texture.js
@@ -531,11 +531,13 @@ x3dom.Texture.prototype.updateText = function()
 	//textY = topToBottom ? 0 : text_canvas.height / oversample;
 	//font_spacing = topToBottom ? font_spacing : -font_spacing;
 	
+	/*
 	switch(textAlignment) {
 		case "left": 	textX = 0; 			break;
 		case "center": 	textX = txtW/2; 	break;
 		case "right": 	textX = txtW;		break;
 	}
+	*/
 	
 	var x_offset = 0, y_offset = 0; baseLine = 'top';
 	
@@ -544,12 +546,15 @@ x3dom.Texture.prototype.updateText = function()
 	switch (font_justify) {
 		case "center":	 
 			x_offset = -txtW/2;
+			textX = txtW/2;
 			break;
 		case "left":
 			x_offset = leftToRight === 'ltr' ? 0 : -txtW;
+			textX = 0;
 			break;
 		case "right":
 			x_offset = leftToRight === 'ltr' ? -txtW : 0;
+			textX = txtW;
 			break;
 	}
 

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -569,7 +569,7 @@ x3dom.Texture.prototype.updateText = function()
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? textHeight : txtH - textHeight; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? textHeight : txtH + textHeight; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			baseLine = topToBottom ? 'alphabetic' : 'bottom';
 			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -561,11 +561,45 @@ x3dom.Texture.prototype.updateText = function()
 
 	var w = txtW / 50.0;
 	var h = txtH / 50.0;
-
-	//this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
-	this.node._mesh._positions[0] = [0, -h, 0,  w, -h, 0,  w, 0, 0,  -w, 0, 0];
 	
+	var x_offset = 0, y_offset = 0;
+	
+	//x_offset
+	switch (font_justify) {
+		case "center":	 
+			x_offset = -w/2;
+			break;
+		case "left":
+			x_offset = leftToRight === 'ltr' ? 0 : -w;
+			break;
+		case "right":
+			x_offset = leftToRight === 'ltr' ? -w : 0;
+			break;
+	}
 
+	//y_offset
+	switch (minor_alignment) {
+		case "MIDDLE":
+			y_offset = h/2;
+			break;
+		case "BEGIN":
+			y_offset = topToBottom ? 0 : h;
+			break;
+		case "FIRST":
+			y_offset = topToBottom ? textHeight * font_spacing : h;
+			break;
+		case "END":
+			y_offset = topToBottom ? h : 0;
+			break;
+	}
+	
+	//this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
+	this.node._mesh._positions[0] = [
+		0 + x_offset, -h + y_offset, 0,
+		w + x_offset, -h + y_offset, 0,
+		w + x_offset,  0 + y_offset, 0,
+		0 + x_offset,  0 + y_offset, 0];
+	
     this.node.invalidateVolume();
     Array.forEach(this.node._parentNodes, function (node) {
         node.setAllDirty();

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -508,12 +508,13 @@ x3dom.Texture.prototype.updateText = function()
 	var maxWidth = 0, pWidth, pLength;
     var i;
 
-	// calculate maxWidth and sanitize lengths
+	// calculate maxWidth and length scaling; sanitize lengths
 	for(i = 0; i < paragraph.length; i++) {
 		pWidth = text_ctx.measureText( paragraph[i] ).width; 
 		if ( pWidth > maxWidth ) { maxWidth = pWidth; }
 		pLength = this.node._vf.length[i] | 0;
 		lengths[i] = pLength <= 0 ? pWidth + 1 : pLength * x3dToPx;
+		//lengths[i] = pLength <=0 ? 1 : pLength * x3dToPx / pWidth; // enable for .scale use
 		//if ( pLength > pWidth || pLength == 0 ) { lengths[i] = pWidth + 1; }
 	}
 	
@@ -533,10 +534,11 @@ x3dom.Texture.prototype.updateText = function()
 	
 	textX /= oversample; //needs to be in unscaled units
 
-	var txtW = text_canvas.width/oversample;
-	var txtH = text_canvas.height/oversample;
+	var txtW = text_canvas.width / oversample;
+	var txtH = text_canvas.height / oversample;
 	
 	//.scale was reset by .width above
+	//move below for length scaling
 	text_ctx.scale(oversample, oversample);
 
 	text_ctx.fillStyle = 'rgba(0,0,0,0)';
@@ -554,7 +556,13 @@ x3dom.Texture.prototype.updateText = function()
 	// create the multiline text
 	for(i = 0; i < paragraph.length; i++) {
 		textY = i * textHeight * font_spacing;
+		//maxWidth does not work for expanding if necessary
+		//redo with .scale(factor, 1)
+		//text_ctx.scale(oversample * lengths[i], oversample);
+		//text_ctx.fillText(paragraph[i], textX / lengths[i],  textY)
 		text_ctx.fillText(paragraph[i], textX,  textY, lengths[i]);
+		//text_ctx.setTransform(1, 0, 0, 1, 0, 0);
+		//reset .transform
 	}
 
 	if( this.texture === null )

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -559,7 +559,7 @@ x3dom.Texture.prototype.updateText = function()
 	//remove canvas after Texture creation
 	document.body.removeChild(text_canvas);
 
-	var pxToX3d = 1/50.0;
+	var pxToX3d = 1/42.0;
 	var w = txtW * pxToX3d;
 	var h = txtH * pxToX3d;
 	
@@ -588,8 +588,8 @@ x3dom.Texture.prototype.updateText = function()
 			break;
 		case "FIRST":
 			//special case of BEGIN;
-			//0.7 factor: on average cap height is about 70% of size
-			y_offset = topToBottom ? 0.7 * textHeight * font_spacing * pxToX3d : h;
+			//0.75 factor: on average cap height is about 70% of size
+			y_offset = topToBottom ? 0.75 * textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -521,7 +521,7 @@ x3dom.Texture.prototype.updateText = function()
 	//shrink maxWidth to max. of lengths
 	//var maxLength = Math.max.apply(lengths);
 	//maxWidth = maxWidth
-	var canvas_scale = 1.1; //needed for some fonts that are higher than the textHeight
+	var canvas_scale = 1.0; //needed for some fonts that are higher than the textHeight
 	canvas_scale *= oversample; //scale up to fit oversampling
 	text_canvas.width = maxWidth * canvas_scale;
 	text_canvas.height = textHeight * font_spacing * paragraph.length * canvas_scale;
@@ -569,7 +569,7 @@ x3dom.Texture.prototype.updateText = function()
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? textHeight : txtH + textHeight; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? textHeight : txtH ; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			baseLine = topToBottom ? 'alphabetic' : 'bottom';
 			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -587,7 +587,9 @@ x3dom.Texture.prototype.updateText = function()
 			y_offset = topToBottom ? 0 : h;
 			break;
 		case "FIRST":
-			y_offset = topToBottom ? textHeight * font_spacing * pxToX3d : h;
+			//special case of BEGIN;
+			//0.7 factor: on average cap height is about 70% of size
+			y_offset = topToBottom ? 0.7 * textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -587,8 +587,8 @@ x3dom.Texture.prototype.updateText = function()
 			y_offset = topToBottom ? 0 : h;
 			break;
 		case "FIRST":
-			//special case of BEGIN;
-			//0.75 factor: on average cap height is about 70% of size
+			//special case of BEGIN
+			//0.75 : on average cap height is about 70% of size; for Times it about 75%
 			y_offset = topToBottom ? 0.75 * textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -576,7 +576,7 @@ x3dom.Texture.prototype.updateText = function()
 			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;
 		case "END":
-			y_offset = topToBottom ? txtH - canvas_extra: textHeight;
+			y_offset = topToBottom ? txtH - canvas_extra: 0;
 			baseLine = topToBottom ? 'bottom' : 'top';
 			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -521,7 +521,7 @@ x3dom.Texture.prototype.updateText = function()
 	//shrink maxWidth to max. of lengths
 	//var maxLength = Math.max.apply(lengths);
 	//maxWidth = maxWidth
-	var canvas_extra = 0.1 * textHeight; //needed for some fonts that are higher than the textHeight
+	var canvas_extra = 0.1 * textHeight; //single line, for some fonts higher than textHeight
 	//canvas_scale *= oversample; //scale up to fit oversampling
 	var txtW = maxWidth ;
 	var txtH = textHeight * font_spacing * paragraph.length + canvas_extra ;
@@ -564,9 +564,9 @@ x3dom.Texture.prototype.updateText = function()
 			y_offset = txtH/2;
 			break;
 		case "BEGIN":
-			y_offset = topToBottom ? textHeight : txtH - canvas_extra;
+			y_offset = topToBottom ? 0 : txtH - canvas_extra;
 			baseLine = topToBottom ? 'top' : 'bottom';
-			textY = topToBottom ? textHeight : 0; // start there to have space
+			textY = topToBottom ? 0 : textHeight; // start there to have space
 			break;
 		case "FIRST":
 			//special case of BEGIN

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -513,7 +513,7 @@ x3dom.Texture.prototype.updateText = function()
 		pWidth = text_ctx.measureText( paragraph[i] ).width; 
 		if ( pWidth > maxWidth ) { maxWidth = pWidth; }
 		pLength = this.node._vf.length[i] | 0;
-		if (maxExtent > 0 && pLength > maxExtent) {
+		if (maxExtent > 0 && (pLength > maxExtent || pLength == 0)) {
 			pLength = maxExtent;	
 		}
 		lengths[i] = pLength <= 0 ? pWidth : pLength * x3dToPx;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -523,22 +523,19 @@ x3dom.Texture.prototype.updateText = function()
 	//maxWidth = maxWidth
 	var canvas_extra = 0.1 * textHeight; //needed for some fonts that are higher than the textHeight
 	//canvas_scale *= oversample; //scale up to fit oversampling
-	text_canvas.width = maxWidth * oversample;
-	text_canvas.height = (textHeight * font_spacing * paragraph.length + canvas_extra) * oversample ;
+	var txtW = maxWidth ;
+	var txtH = textHeight * font_spacing * paragraph.length + canvas_extra ;
 
-	switch(textAlignment) {
-		case "left": 	textX = 0; 						break;
-		case "center": 	textX = text_canvas.width/2; 	break;
-		case "right": 	textX = text_canvas.width;		break;
-	}
-	
-	textX /= oversample; //needs to be in unscaled units
+	textX = 0; //needs to be in unscaled units
 	textY = 0;
 	//textY = topToBottom ? 0 : text_canvas.height / oversample;
 	//font_spacing = topToBottom ? font_spacing : -font_spacing;
 	
-	var txtW = text_canvas.width / oversample;
-	var txtH = text_canvas.height / oversample;
+	switch(textAlignment) {
+		case "left": 	textX = 0; 			break;
+		case "center": 	textX = txtW/2; 	break;
+		case "right": 	textX = txtW;		break;
+	}
 	
 	var x_offset = 0, y_offset = 0; baseLine = 'top';
 	
@@ -588,6 +585,9 @@ x3dom.Texture.prototype.updateText = function()
 	
 	//.scale was reset by .width above
 	//move below for length scaling
+	text_canvas.width = txtW * oversample ;
+	text_canvas.height = txtH * oversample ;
+
 	text_ctx.scale(oversample, oversample);
 
 	text_ctx.fillStyle = 'rgba(0,0,0,0)';

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -559,8 +559,9 @@ x3dom.Texture.prototype.updateText = function()
 	//remove canvas after Texture creation
 	document.body.removeChild(text_canvas);
 
-	var w = txtW / 50.0;
-	var h = txtH / 50.0;
+	var pxToX3d = 1/50.0;
+	var w = txtW * pxToX3d;
+	var h = txtH * pxToX3d;
 	
 	var x_offset = 0, y_offset = 0;
 	
@@ -586,7 +587,7 @@ x3dom.Texture.prototype.updateText = function()
 			y_offset = topToBottom ? 0 : h;
 			break;
 		case "FIRST":
-			y_offset = topToBottom ? textHeight * font_spacing : h;
+			y_offset = topToBottom ? textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -493,7 +493,8 @@ x3dom.Texture.prototype.updateText = function()
 	var lengths = [];
 	var text_canvas = document.createElement('canvas');
 	text_canvas.dir = leftToRight;
-	var textHeight = font_size * 42; // pixel size relative to local coordinate system
+	var x3dToPx = 42;
+	var textHeight = font_size * x3dToPx; // pixel size relative to local coordinate system
 	var textAlignment = font_justify;
 	
 	// needed to make webfonts work
@@ -512,7 +513,7 @@ x3dom.Texture.prototype.updateText = function()
 		pWidth = text_ctx.measureText( paragraph[i] ).width; 
 		if ( pWidth > maxWidth ) { maxWidth = pWidth; }
 		pLength = this.node._vf.length[i] | 0;
-		lengths[i] = pLength <= 0 ? pWidth + 1 : pLength;
+		lengths[i] = pLength <= 0 ? pWidth + 1 : pLength * x3dToPx;
 		//if ( pLength > pWidth || pLength == 0 ) { lengths[i] = pWidth + 1; }
 	}
 	

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -540,50 +540,52 @@ x3dom.Texture.prototype.updateText = function()
 	var txtW = text_canvas.width / oversample;
 	var txtH = text_canvas.height / oversample;
 	
-	var pxToX3d = 1/42.0;
-	var w = txtW * pxToX3d;
-	var h = txtH * pxToX3d;
-	
 	var x_offset = 0, y_offset = 0; baseLine = 'top';
 	
 	//Todo: make into lookup object
 	//x_offset
 	switch (font_justify) {
 		case "center":	 
-			x_offset = -w/2;
+			x_offset = -txtW/2;
 			break;
 		case "left":
-			x_offset = leftToRight === 'ltr' ? 0 : -w;
+			x_offset = leftToRight === 'ltr' ? 0 : -txtW;
 			break;
 		case "right":
-			x_offset = leftToRight === 'ltr' ? -w : 0;
+			x_offset = leftToRight === 'ltr' ? -txtW : 0;
 			break;
 	}
 
 	//y_offset, baseline and first Y
 	switch (minor_alignment) {
 		case "MIDDLE":
-			y_offset = h/2;
+			y_offset = txtH/2;
 			break;
 		case "BEGIN":
-			y_offset = topToBottom ? textHeight * pxToX3d : h;
+			y_offset = topToBottom ? textHeight : txtH;
 			baseLine = topToBottom ? 'top' : 'bottom';
 			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? textHeight : txtH - textHeight; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			baseLine = topToBottom ? 'alphabetic' : 'bottom';
 			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;
 		case "END":
-			y_offset = topToBottom ? h : textHeight * pxToX3d;
+			y_offset = topToBottom ? txtH : textHeight;
 			baseLine = topToBottom ? 'bottom' : 'top';
 			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 	}
-		
+	
+	var pxToX3d = 1/42.0;
+	var w = txtW * pxToX3d;
+	var h = txtH * pxToX3d;
+	x_offset *= pxToX3d;
+	y_offset *= pxToX3d;
+	
 	//.scale was reset by .width above
 	//move below for length scaling
 	text_ctx.scale(oversample, oversample);

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -410,8 +410,8 @@ x3dom.Texture.prototype.updateText = function()
 	this.wrapT			= gl.CLAMP_TO_EDGE;
 	this.type = gl.TEXTURE_2D;
     this.format = gl.RGBA;
-    this.magFilter = gl.LINEAR;
-    this.minFilter = gl.LINEAR;
+	this.magFilter = gl.LINEAR;
+	this.minFilter = gl.LINEAR;
     
 	var fontStyleNode = this.node._cf.fontStyle.node; // should always exist?
 
@@ -507,7 +507,7 @@ x3dom.Texture.prototype.updateText = function()
 	text_ctx.font = font_style + " " + textHeight + "px " + font_family;
 
 	var maxWidth = 0, pWidth, pLength;
-    var i, j;
+	var i, j;
 
 	// calculate maxWidth and length scaling; sanitize lengths
 	for(i = 0; i < paragraph.length; i++) {
@@ -619,9 +619,8 @@ x3dom.Texture.prototype.updateText = function()
 		w + x_offset,  0 + y_offset, 0,
 		0 + x_offset,  0 + y_offset, 0];
 	
-    this.node.invalidateVolume();
-    Array.forEach(this.node._parentNodes, function (node) {
-        node.setAllDirty();
+	this.node.invalidateVolume();
+	Array.forEach(this.node._parentNodes, function (node) {
+    	node.setAllDirty();
     });
 };
-

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -409,7 +409,7 @@ x3dom.Texture.prototype.updateText = function()
 	this.wrapS			= gl.CLAMP_TO_EDGE;
 	this.wrapT			= gl.CLAMP_TO_EDGE;
 	this.type = gl.TEXTURE_2D;
-    this.format = gl.RGBA;
+	this.format = gl.RGBA;
 	this.magFilter = gl.LINEAR;
 	this.minFilter = gl.LINEAR;
     

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -521,10 +521,10 @@ x3dom.Texture.prototype.updateText = function()
 	//shrink maxWidth to max. of lengths
 	//var maxLength = Math.max.apply(lengths);
 	//maxWidth = maxWidth
-	var canvas_extra = 0.1; //needed for some fonts that are higher than the textHeight
+	var canvas_extra = 0.1 * textHeight; //needed for some fonts that are higher than the textHeight
 	//canvas_scale *= oversample; //scale up to fit oversampling
 	text_canvas.width = maxWidth * oversample;
-	text_canvas.height = (textHeight * font_spacing * paragraph.length + canvas_extra * textHeight) * oversample ;
+	text_canvas.height = (textHeight * font_spacing * paragraph.length + canvas_extra) * oversample ;
 
 	switch(textAlignment) {
 		case "left": 	textX = 0; 						break;
@@ -543,7 +543,7 @@ x3dom.Texture.prototype.updateText = function()
 	var x_offset = 0, y_offset = 0; baseLine = 'top';
 	
 	//Todo: make into lookup object
-	//x_offset
+	//x_offset and starting X
 	switch (font_justify) {
 		case "center":	 
 			x_offset = -txtW/2;
@@ -562,19 +562,19 @@ x3dom.Texture.prototype.updateText = function()
 			y_offset = txtH/2;
 			break;
 		case "BEGIN":
-			y_offset = topToBottom ? textHeight : txtH;
+			y_offset = topToBottom ? textHeight : txtH - canvas_extra;
 			baseLine = topToBottom ? 'top' : 'bottom';
 			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? textHeight : txtH ; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? textHeight : txtH - canvas_extra ; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			baseLine = topToBottom ? 'alphabetic' : 'bottom';
 			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;
 		case "END":
-			y_offset = topToBottom ? txtH : textHeight;
+			y_offset = topToBottom ? txtH - canvas_extra: textHeight;
 			baseLine = topToBottom ? 'bottom' : 'top';
 			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -502,7 +502,7 @@ x3dom.Texture.prototype.updateText = function()
 
 	var text_ctx = text_canvas.getContext('2d');
 
-	// calculate font font_size in px
+	// calculate font_size in px
 	text_ctx.font = font_style + " " + textHeight + "px " + font_family;
 
 	var maxWidth = 0, pWidth, pLength;
@@ -513,7 +513,10 @@ x3dom.Texture.prototype.updateText = function()
 		pWidth = text_ctx.measureText( paragraph[i] ).width; 
 		if ( pWidth > maxWidth ) { maxWidth = pWidth; }
 		pLength = this.node._vf.length[i] | 0;
-		lengths[i] = pLength <= 0 ? pWidth + 1 : pLength * x3dToPx;
+		if (maxExtent > 0 && pLength > maxExtent) {
+			pLength = maxExtent;	
+		}
+		lengths[i] = pLength <= 0 ? pWidth : pLength * x3dToPx;
 		//lengths[i] = pLength <=0 ? 1 : pLength * x3dToPx / pWidth; // enable for .scale use
 		//if ( pLength > pWidth || pLength == 0 ) { lengths[i] = pWidth + 1; }
 	}
@@ -585,6 +588,7 @@ x3dom.Texture.prototype.updateText = function()
 	var pxToX3d = 1/42.0;
 	var w = txtW * pxToX3d;
 	var h = txtH * pxToX3d;
+	
 	x_offset *= pxToX3d;
 	y_offset *= pxToX3d;
 	
@@ -594,7 +598,6 @@ x3dom.Texture.prototype.updateText = function()
 	text_canvas.height = txtH * oversample ;
 	text_canvas.dir = leftToRight;
 	
-
 	text_ctx.scale(oversample, oversample);
 
 	text_ctx.fillStyle = 'rgba(0,0,0,0)';
@@ -633,7 +636,6 @@ x3dom.Texture.prototype.updateText = function()
 
 	//remove canvas after Texture creation
 	document.body.removeChild(text_canvas);
-
 
 	//this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
 	this.node._mesh._positions[0] = [

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -565,7 +565,7 @@ x3dom.Texture.prototype.updateText = function()
 		//text_ctx.scale(oversample * lengths[i], oversample);
 		//text_ctx.fillText(paragraph[i], textX / lengths[i],  textY)
 		j = topToBottom ? i : paragraph.length - i - 1;
-		text_ctx.fillText(paragraph[j], textX,  textY, lengths[i]);
+		text_ctx.fillText(paragraph[j], textX,  textY, lengths[j]);
 		//text_ctx.setTransform(1, 0, 0, 1, 0, 0);
 		//reset .transform
 		textY += textHeight * font_spacing;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -560,23 +560,27 @@ x3dom.Texture.prototype.updateText = function()
 			break;
 	}
 
-	//y_offset and baseline
+	//y_offset, baseline and first Y
 	switch (minor_alignment) {
 		case "MIDDLE":
 			y_offset = h/2;
 			break;
 		case "BEGIN":
-			y_offset = topToBottom ? 0 : h;
+			y_offset = topToBottom ? textHeight * pxToX3d : h;
+			baseLine = topToBottom ? 'top' : 'bottom';
+			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
 			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
-			baseLine = topToBottom ? 'alphabetic' : 'top';
-			textY = topToBottom ? textHeight : 0; // start there to have space
+			baseLine = topToBottom ? 'alphabetic' : 'bottom';
+			textY = topToBottom ? textHeight : textHeight; // start there to have space
 			break;
 		case "END":
-			y_offset = topToBottom ? h : 0;
+			y_offset = topToBottom ? h : textHeight * pxToX3d;
+			baseLine = topToBottom ? 'bottom' : 'top';
+			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 	}
 		

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -448,7 +448,7 @@ x3dom.Texture.prototype.updateText = function()
 		var leftToRight = fontStyleNode._vf.leftToRight ? 'ltr' : 'rtl';
 		var topToBottom = fontStyleNode._vf.topToBottom;
 
-		// TODO: make it possible to use multiple values
+		// TODO: make it possible to use both values
 		font_justify = fontStyleNode._vf.justify[0].toString().replace(/\'/g,'');
 		switch (font_justify.toUpperCase()) {
 			case 'BEGIN': 	font_justify = 'left'; 		break;
@@ -458,13 +458,18 @@ x3dom.Texture.prototype.updateText = function()
 			default: 		font_justify = 'left'; 		break;
 		}
 		
-		minor_alignment = fontStyleNode._vf.justify[1].toString().replace(/\'/g,'');
-		switch (minor_alignment.toUpperCase()) {
-			case 'BEGIN': 		minor_alignment = 'BEGIN'; 		break;
-			case 'FIRST': 		minor_alignment = 'FIRST'; 		break;
-			case 'MIDDLE': 		minor_alignment = 'MIDDLE'; 	break;
-			case 'END': 		minor_alignment = 'END'; 		break;
-			default: 			minor_alignment = 'FIRST'; 		break;
+		if (fontStyleNode._vf.justify[1] === undefined) {
+			minor_alignment = 'FIRST';
+		}
+		else {
+			minor_alignment = fontStyleNode._vf.justify[1].toString().replace(/\'/g,'');
+			switch (minor_alignment.toUpperCase()) {
+				case 'BEGIN': 		minor_alignment = 'BEGIN'; 		break;
+				case 'FIRST': 		minor_alignment = 'FIRST'; 		break;
+				case 'MIDDLE': 		minor_alignment = 'MIDDLE'; 	break;
+				case 'END': 		minor_alignment = 'END'; 		break;
+				default: 			minor_alignment = 'FIRST'; 		break;
+			}
 		}
 		
 		font_size 		= fontStyleNode._vf.size;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -592,6 +592,8 @@ x3dom.Texture.prototype.updateText = function()
 	//move below for length scaling
 	text_canvas.width = txtW * oversample ;
 	text_canvas.height = txtH * oversample ;
+	text_canvas.dir = leftToRight;
+	
 
 	text_ctx.scale(oversample, oversample);
 

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -533,8 +533,7 @@ x3dom.Texture.prototype.updateText = function()
 	}
 	
 	textX /= oversample; //needs to be in unscaled units
-	textY = minor_alignment == 'FIRST' && topToBottom ? textHeight : 0; // start there to have space
-
+	textY = 0;
 	//textY = topToBottom ? 0 : text_canvas.height / oversample;
 	//font_spacing = topToBottom ? font_spacing : -font_spacing;
 	
@@ -573,7 +572,8 @@ x3dom.Texture.prototype.updateText = function()
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
 			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
-			baseLine = 'alphabetic';
+			baseLine = topToBottom ? 'alphabetic' : 'top';
+			textY = topToBottom ? textHeight : 0; // start there to have space
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -506,7 +506,7 @@ x3dom.Texture.prototype.updateText = function()
 	text_ctx.font = font_style + " " + textHeight + "px " + font_family;
 
 	var maxWidth = 0, pWidth, pLength;
-    var i;
+    var i, j;
 
 	// calculate maxWidth and length scaling; sanitize lengths
 	for(i = 0; i < paragraph.length; i++) {
@@ -533,7 +533,11 @@ x3dom.Texture.prototype.updateText = function()
 	}
 	
 	textX /= oversample; //needs to be in unscaled units
+	textY = minor_alignment == 'FIRST' && topToBottom ? textHeight : 0; // start there to have space
 
+	//textY = topToBottom ? 0 : text_canvas.height / oversample;
+	//font_spacing = topToBottom ? font_spacing : -font_spacing;
+	
 	var txtW = text_canvas.width / oversample;
 	var txtH = text_canvas.height / oversample;
 	
@@ -556,14 +560,15 @@ x3dom.Texture.prototype.updateText = function()
 
 	// create the multiline text
 	for(i = 0; i < paragraph.length; i++) {
-		textY = i * textHeight * font_spacing;
 		//maxWidth does not work for expanding if necessary
 		//redo with .scale(factor, 1)
 		//text_ctx.scale(oversample * lengths[i], oversample);
 		//text_ctx.fillText(paragraph[i], textX / lengths[i],  textY)
-		text_ctx.fillText(paragraph[i], textX,  textY, lengths[i]);
+		j = topToBottom ? i : paragraph.length - j - 1;
+		text_ctx.fillText(paragraph[j], textX,  textY, lengths[i]);
 		//text_ctx.setTransform(1, 0, 0, 1, 0, 0);
 		//reset .transform
+		textY += textHeight * font_spacing;
 	}
 
 	if( this.texture === null )
@@ -608,7 +613,7 @@ x3dom.Texture.prototype.updateText = function()
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? 0 : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -564,7 +564,7 @@ x3dom.Texture.prototype.updateText = function()
 		//redo with .scale(factor, 1)
 		//text_ctx.scale(oversample * lengths[i], oversample);
 		//text_ctx.fillText(paragraph[i], textX / lengths[i],  textY)
-		j = topToBottom ? i : paragraph.length - j - 1;
+		j = topToBottom ? i : paragraph.length - i - 1;
 		text_ctx.fillText(paragraph[j], textX,  textY, lengths[i]);
 		//text_ctx.setTransform(1, 0, 0, 1, 0, 0);
 		//reset .transform

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -409,17 +409,18 @@ x3dom.Texture.prototype.updateText = function()
 	this.wrapS			= gl.CLAMP_TO_EDGE;
 	this.wrapT			= gl.CLAMP_TO_EDGE;
 
-	var fontStyleNode = this.node._cf.fontStyle.node; // should always exist
+	var fontStyleNode = this.node._cf.fontStyle.node; // should always exist?
 
-    var font_family = 'serif'; //should be dealt with by default fontStyleNode?
+    var font_family = 'serif'; // should be dealt with by default fontStyleNode?
     var font_style = 'normal';
     var font_justify = 'left';
     var font_size = 1.0;
     var font_spacing = 1.0;
     var font_horizontal = true;
     var font_language = "";
+    var oversample = 2.0;
 
-    if ( fontStyleNode !== null ) 
+    if ( fontStyleNode !== null )
 	{
 		var fonts = fontStyleNode._vf.family.toString();
 
@@ -452,7 +453,7 @@ x3dom.Texture.prototype.updateText = function()
 		switch (font_justify.toUpperCase()) {
 			case 'BEGIN': 	font_justify = 'left'; 		break;
 			case 'END': 	font_justify = 'right'; 	break;
-			case 'FIRST': 	font_justify = 'left'; 		break; // relevant only in justify[1]
+			case 'FIRST': 	font_justify = 'left'; 		break; // relevant only in justify[1], eg. minor alignment
 			case 'MIDDLE': 	font_justify = 'center'; 	break;
 			default: 		font_justify = 'left'; 		break;
 		}
@@ -461,7 +462,10 @@ x3dom.Texture.prototype.updateText = function()
 		font_spacing 	= fontStyleNode._vf.spacing;
 		font_horizontal = fontStyleNode._vf.horizontal;
 		font_language 	= fontStyleNode._vf.language;
-
+		oversample = fontStyleNode._vf.quality;
+		oversample = Math.max(x3dom.Texture.minFontQuality, oversample);
+		oversample = Math.min(x3dom.Texture.maxFontQuality, oversample);
+	
         if (font_size < 0.1) font_size = 0.1;
         if(x3dom.Texture.clampFontSize && font_size > 2.3)
         {
@@ -475,9 +479,6 @@ x3dom.Texture.prototype.updateText = function()
 	text_canvas.dir = leftToRight;
 	var textHeight = font_size * 42; // pixel size relative to local coordinate system
 	var textAlignment = font_justify;
-	var oversample = fontStyleNode._vf.quality;
-	oversample = Math.max(x3dom.Texture.minFontQuality, oversample);
-	oversample = Math.min(x3dom.Texture.maxFontQuality, oversample);
 	
 	// needed to make webfonts work
 	document.body.appendChild(text_canvas);

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -548,7 +548,8 @@ x3dom.Texture.prototype.updateText = function()
 	text_ctx.fillStyle = 'white';
 	text_ctx.lineWidth = 2.5; // not used ?
 	text_ctx.strokeStyle = 'grey'; // not used ?
-	text_ctx.textBaseline = 'top';
+	text_ctx.textBaseline = 
+		minor_alignment == 'FIRST' && topToBottom ? 'alphabetic' : 'top';
 
 	text_ctx.font = font_style + " " + textHeight + "px " + font_family;
 	text_ctx.textAlign = textAlignment;
@@ -607,7 +608,7 @@ x3dom.Texture.prototype.updateText = function()
 		case "FIRST":
 			//special case of BEGIN
 			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? 0.75 * textHeight * font_spacing * pxToX3d : h;
+			y_offset = topToBottom ? 0 : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
 			break;
 		case "END":
 			y_offset = topToBottom ? h : 0;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -541,6 +541,45 @@ x3dom.Texture.prototype.updateText = function()
 	var txtW = text_canvas.width / oversample;
 	var txtH = text_canvas.height / oversample;
 	
+	var pxToX3d = 1/42.0;
+	var w = txtW * pxToX3d;
+	var h = txtH * pxToX3d;
+	
+	var x_offset = 0, y_offset = 0; baseLine = 'top';
+	
+	//Todo: make into lookup object
+	//x_offset
+	switch (font_justify) {
+		case "center":	 
+			x_offset = -w/2;
+			break;
+		case "left":
+			x_offset = leftToRight === 'ltr' ? 0 : -w;
+			break;
+		case "right":
+			x_offset = leftToRight === 'ltr' ? -w : 0;
+			break;
+	}
+
+	//y_offset and baseline
+	switch (minor_alignment) {
+		case "MIDDLE":
+			y_offset = h/2;
+			break;
+		case "BEGIN":
+			y_offset = topToBottom ? 0 : h;
+			break;
+		case "FIRST":
+			//special case of BEGIN
+			//0.75 : on average cap height is about 70% of size; for Times it about 75%
+			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
+			baseLine = 'alphabetic';
+			break;
+		case "END":
+			y_offset = topToBottom ? h : 0;
+			break;
+	}
+		
 	//.scale was reset by .width above
 	//move below for length scaling
 	text_ctx.scale(oversample, oversample);
@@ -552,8 +591,7 @@ x3dom.Texture.prototype.updateText = function()
 	text_ctx.fillStyle = 'white';
 	text_ctx.lineWidth = 2.5; // not used ?
 	text_ctx.strokeStyle = 'grey'; // not used ?
-	text_ctx.textBaseline = 
-		minor_alignment == 'FIRST' && topToBottom ? 'alphabetic' : 'top';
+	text_ctx.textBaseline = baseLine;
 
 	text_ctx.font = font_style + " " + textHeight + "px " + font_family;
 	text_ctx.textAlign = textAlignment;
@@ -583,43 +621,7 @@ x3dom.Texture.prototype.updateText = function()
 	//remove canvas after Texture creation
 	document.body.removeChild(text_canvas);
 
-	var pxToX3d = 1/42.0;
-	var w = txtW * pxToX3d;
-	var h = txtH * pxToX3d;
-	
-	var x_offset = 0, y_offset = 0;
-	
-	//x_offset
-	switch (font_justify) {
-		case "center":	 
-			x_offset = -w/2;
-			break;
-		case "left":
-			x_offset = leftToRight === 'ltr' ? 0 : -w;
-			break;
-		case "right":
-			x_offset = leftToRight === 'ltr' ? -w : 0;
-			break;
-	}
 
-	//y_offset
-	switch (minor_alignment) {
-		case "MIDDLE":
-			y_offset = h/2;
-			break;
-		case "BEGIN":
-			y_offset = topToBottom ? 0 : h;
-			break;
-		case "FIRST":
-			//special case of BEGIN
-			//0.75 : on average cap height is about 70% of size; for Times it about 75%
-			y_offset = topToBottom ? textHeight * pxToX3d : h; //0.75 * textHeight * font_spacing * pxToX3d : h;
-			break;
-		case "END":
-			y_offset = topToBottom ? h : 0;
-			break;
-	}
-	
 	//this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
 	this.node._mesh._positions[0] = [
 		0 + x_offset, -h + y_offset, 0,

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -419,6 +419,7 @@ x3dom.Texture.prototype.updateText = function()
     var font_horizontal = true;
     var font_language = "";
     var oversample = 2.0;
+    var minor_alignment = 'FIRST';
 
     if ( fontStyleNode !== null )
 	{
@@ -449,7 +450,6 @@ x3dom.Texture.prototype.updateText = function()
 
 		// TODO: make it possible to use multiple values
 		font_justify = fontStyleNode._vf.justify[0].toString().replace(/\'/g,'');
-
 		switch (font_justify.toUpperCase()) {
 			case 'BEGIN': 	font_justify = 'left'; 		break;
 			case 'END': 	font_justify = 'right'; 	break;
@@ -457,7 +457,16 @@ x3dom.Texture.prototype.updateText = function()
 			case 'MIDDLE': 	font_justify = 'center'; 	break;
 			default: 		font_justify = 'left'; 		break;
 		}
-
+		
+		minor_alignment = fontStyleNode._vf.justify[1].toString().replace(/\'/g,'');
+		switch (minor_alignment.toUpperCase()) {
+			case 'BEGIN': 		minor_alignment = 'BEGIN'; 		break;
+			case 'FIRST': 		minor_alignment = 'FIRST'; 		break;
+			case 'MIDDLE': 		minor_alignment = 'MIDDLE'; 	break;
+			case 'END': 		minor_alignment = 'END'; 		break;
+			default: 			minor_alignment = 'FIRST'; 		break;
+		}
+		
 		font_size 		= fontStyleNode._vf.size;
 		font_spacing 	= fontStyleNode._vf.spacing;
 		font_horizontal = fontStyleNode._vf.horizontal;
@@ -545,10 +554,12 @@ x3dom.Texture.prototype.updateText = function()
 	//remove canvas after Texture creation
 	document.body.removeChild(text_canvas);
 
-	var w = txtW / 100.0;
-	var h = txtH / 100.0;
+	var w = txtW / 50.0;
+	var h = txtH / 50.0;
 
-	this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
+	//this.node._mesh._positions[0] = [-w,-h+.4,0, w,-h+.4,0, w,h+.4,0, -w,h+.4,0];
+	this.node._mesh._positions[0] = [0, -h, 0,  w, -h, 0,  w, 0, 0,  -w, 0, 0];
+	
 
     this.node.invalidateVolume();
     Array.forEach(this.node._parentNodes, function (node) {

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -521,10 +521,10 @@ x3dom.Texture.prototype.updateText = function()
 	//shrink maxWidth to max. of lengths
 	//var maxLength = Math.max.apply(lengths);
 	//maxWidth = maxWidth
-	var canvas_scale = 1.0; //needed for some fonts that are higher than the textHeight
-	canvas_scale *= oversample; //scale up to fit oversampling
-	text_canvas.width = maxWidth * canvas_scale;
-	text_canvas.height = textHeight * font_spacing * paragraph.length * canvas_scale;
+	var canvas_extra = 0.1; //needed for some fonts that are higher than the textHeight
+	//canvas_scale *= oversample; //scale up to fit oversampling
+	text_canvas.width = maxWidth * oversample;
+	text_canvas.height = (textHeight * font_spacing * paragraph.length + canvas_extra * textHeight) * oversample ;
 
 	switch(textAlignment) {
 		case "left": 	textX = 0; 						break;

--- a/src/Texture.js
+++ b/src/Texture.js
@@ -409,9 +409,9 @@ x3dom.Texture.prototype.updateText = function()
 	this.wrapS			= gl.CLAMP_TO_EDGE;
 	this.wrapT			= gl.CLAMP_TO_EDGE;
 
-	var fontStyleNode = this.node._cf.fontStyle.node;
+	var fontStyleNode = this.node._cf.fontStyle.node; // should always exist
 
-    var font_family = 'serif';
+    var font_family = 'serif'; //should be dealt with by default fontStyleNode?
     var font_style = 'normal';
     var font_justify = 'left';
     var font_size = 1.0;
@@ -419,7 +419,7 @@ x3dom.Texture.prototype.updateText = function()
     var font_horizontal = true;
     var font_language = "";
 
-    if ( fontStyleNode !== null )
+    if ( fontStyleNode !== null ) 
 	{
 		var fonts = fontStyleNode._vf.family.toString();
 
@@ -452,7 +452,7 @@ x3dom.Texture.prototype.updateText = function()
 		switch (font_justify.toUpperCase()) {
 			case 'BEGIN': 	font_justify = 'left'; 		break;
 			case 'END': 	font_justify = 'right'; 	break;
-			case 'FIRST': 	font_justify = 'left'; 		break; // not clear what to do with this one
+			case 'FIRST': 	font_justify = 'left'; 		break; // relevant only in justify[1]
 			case 'MIDDLE': 	font_justify = 'center'; 	break;
 			default: 		font_justify = 'left'; 		break;
 		}
@@ -498,7 +498,7 @@ x3dom.Texture.prototype.updateText = function()
 	var canvas_scale = 1.1; //needed for some fonts that are higher than the textHeight
 	canvas_scale *= oversample; //scale up to fit oversampling
 	text_canvas.width = maxWidth * canvas_scale;
-	text_canvas.height = textHeight * paragraph.length * canvas_scale; //TODO: font_spacing
+	text_canvas.height = textHeight * font_spacing * paragraph.length * canvas_scale; //font_spacing
 
 	switch(textAlignment) {
 		case "left": 	textX = 0; 						break;
@@ -528,7 +528,7 @@ x3dom.Texture.prototype.updateText = function()
 
 	// create the multiline text
 	for(i = 0; i < paragraph.length; i++) {
-		textY = i*textHeight; //TODO: font_spacing
+		textY = i * textHeight * font_spacing; //font_spacing
 		text_ctx.fillText(paragraph[i], textX,  textY);
 	}
 

--- a/src/nodes/Text/FontStyle.js
+++ b/src/nodes/Text/FontStyle.js
@@ -140,7 +140,9 @@ x3dom.registerNodeType(
                     fieldName == 'language' || fieldName == 'leftToRight' || fieldName == 'size' ||
                     fieldName == 'spacing' || fieldName == 'style' || fieldName == 'topToBottom') {
                     Array.forEach(this._parentNodes, function (node) {
-                        node.nodeChanged();
+                        Array.forEach(node._parentNodes, function (textnode) {
+                            textnode.setAllDirty();
+                        });
                     });
                 }
             }

--- a/src/nodes/Text/FontStyle.js
+++ b/src/nodes/Text/FontStyle.js
@@ -140,7 +140,7 @@ x3dom.registerNodeType(
                     fieldName == 'language' || fieldName == 'leftToRight' || fieldName == 'size' ||
                     fieldName == 'spacing' || fieldName == 'style' || fieldName == 'topToBottom') {
                     Array.forEach(this._parentNodes, function (node) {
-                        node.fieldChanged(fieldName);
+                        node.nodeChanged();
                     });
                 }
             }

--- a/src/nodes/Text/FontStyle.js
+++ b/src/nodes/Text/FontStyle.js
@@ -48,7 +48,8 @@ x3dom.registerNodeType(
             this.addField_SFBool(ctx, 'horizontal', true);
 
             /**
-             * Specifies where the text is anchored.
+             * Specifies where the text is anchored. The default of ["MIDDLE", "MIDDLE"] deviates from the ISO spec. default
+             * of ["BEGIN", "FIRST"] for backward compatibiliy reasons. 
              * @var {x3dom.fields.MFString} justify
              * @range ["BEGIN","END","FIRST","MIDDLE",""]
              * @memberof x3dom.nodeTypes.FontStyle
@@ -56,7 +57,7 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_MFString(ctx, 'justify', ['BEGIN']);
+            this.addField_MFString(ctx, 'justify', ['MIDDLE', 'MIDDLE']);
 
             /**
              * The language field specifies the context of the language for the text string in the form of a language and a country in which that language is used.


### PR DESCRIPTION
The PR addresses issue #545. It adds proper positioning and support for all combinations these fields of the FontStyle node:
- justify: added minor alignment, including for FIRST
- topToBottom: added false (bottom to top)

The horizontal=false and leftToRight=false options are not or only partially supported due to lack of these features in canvas text rendering by web browsers.

The default for justify is modified to MIDDLE MIDDLE for backwards compatibility.

Also, the text node length and maxExtent fields are implemented except that text length will only be shortened and never expanded.