### PR TITLE
fix for escaped quotes in text node

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -3162,7 +3162,7 @@ x3dom.fields.MFString.parse = function(str) {
     if (str.length && str[0] == '"') {
         var m, re = /"((?:[^\\"]|\\\\|\\")*)"/g;
         while ((m = re.exec(str))) {
-            var s = m[1].replace(/\\([\\"])/, "$1");
+            var s = m[1].replace(/\\([\\"])/g, "$1");
             if (s !== undefined) {
                 arr.push(s);
             }


### PR DESCRIPTION
addresses #560.
Test by clicking button in http://andreasplesch.github.io/x3dom/x3dom_text/