### PR TITLE
use mapbox/earcut library for efficient earclipping

### DIFF
--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -53,7 +53,8 @@ x3dom.EarClipping = {
 		
 		points = [];
 		
-		for (i = linklist.length-1; i >= 0; i--) {
+		//for (i = linklist.length-1; i >= 0; i--) {
+		for (i = 0; i < linklist.length; i++) {
 			node = linklist.getNode(i);
 			switch (plane) {
 				case "XY": { x = node.point.x; y = node.point.y; break; }

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -4,193 +4,80 @@
  *
  * (C)2009 Fraunhofer IGD, Darmstadt, Germany
  * Dual licensed under the MIT and GPL
- * (C)2015 improvements by Andreas Plesch
  *
  * Based on code originally provided by
  * Philip Taylor: http://philip.html5.org
  */
 
-
 x3dom.EarClipping = {
 	
-	reversePointDirection: function (linklist, plane) {
-			var l, k;
-			var z = 0;
-			var nodei, nodel, nodek;
-			
-			if (linklist.length < 3) {
-				return false;
-			}
-			
-			for (var i = 0; i < linklist.length; i++) {
-				l = (i + 1) % linklist.length;
-				
-				nodei = linklist.getNode(i);
-				nodel = linklist.getNode(l);
-				// use standard shoelace			
-				if(plane == 'YZ') {
-					z  += (nodel.point.y - nodei.point.y) * (nodel.point.z + nodei.point.z);
-				} else if(plane == 'XZ') {
-					z  += (nodel.point.z - nodei.point.z) * (nodel.point.x + nodei.point.x);
-				} else {
-					z  += (nodel.point.x - nodei.point.x) * (nodel.point.y + nodei.point.y);
-				}
-			}
-			//if counterclockwise
-			if (z > 0) {
-				linklist.invert();
-				return true;
-			}	
-			return false;
-	}, 
-	
 	getIndexes: function (linklist) {
+		
 		var node = linklist.first.next;
 		var plane = this.identifyPlane(node.prev.point, node.point, node.next.point);
+		console.log(plane);
+		var i, points, x, y;
+		points = [];
+		point_indexes = [];
 		
-		var invers = this.reversePointDirection(linklist, plane);
-		var indexes = [];
-		node = linklist.first.next;
-		var next = null;
-		var timeout = 5000;
-		var t0 = Date.now();
-			
-		var isEar = true;
-		while(linklist.length >= 3)  {
-			next = node.next;
-			if(this.isKonvex(node.prev.point, node.point, node.next.point, plane)) {
-				for(var i = 0; i < linklist.length; i++) {
-					if(this.isNotEar(linklist.getNode(i).point, node.prev.point, node.point, node.next.point, plane)) {
-						isEar = false;
-						break; // one point in triangle suffices
-					}
-				}
-				if(isEar) {
-					indexes.push(node.prev.point_index, node.point_index, node.next.point_index);
-					linklist.deleteNode(node);
-				}
+		for (i = 0; i < linklist.length; i++) {
+			node = linklist.getNode(i);
+			switch (plane) {
+				case "XY": { x = node.point.x; y = node.point.y; break; }
+				case "XZ": { x = node.point.z; y = node.point.x; break; }
+				default: { x = node.point.y; y = node.point.z; }
 			}
-			node = next;
-			isEar = true;
-			if (Date.now() - t0 > timeout) { x3dom.debug.logError("Ear clipping timed out."); break; }
+			points.push(y);
+			points.push(x);
+			point_indexes.push(node.point_index);
 		}
-		
-		if(invers){
-			return indexes.reverse();
-		} else {
-			return indexes;
-		}
+		var triangles = x3dom.EarCut.triangulate(points, null, 2);
+		triangles = triangles.map(function(el) {return point_indexes[el];}) ;
+		return triangles;
 	},
 
 	getMultiIndexes: function (linklist) {
 		var node = linklist.first.next;
 		var plane = this.identifyPlane(node.prev.point, node.point, node.next.point);
-		var invers = this.reversePointDirection(linklist, plane);
-		
 		var data = {};
 		data.indices = [];
 		data.point = [];
 		data.normals = [];
 		data.colors = [];
 		data.texCoords = [];
-		node = linklist.first.next;
-		var next = null;
-		var timeout = 5000;
-		var t0 = Date.now();
+		var mapped = {};
+		mapped.indices = [];
+		mapped.point = [];
+		mapped.normals = [];
+		mapped.colors = [];
+		mapped.texCoords = [];
 		
-		var isEar = true;
-		while(linklist.length >= 3) {
-			next = node.next;
-			if(this.isKonvex(node.prev.point, node.point, node.next.point, plane)) {
-				for(var i = 0; i < linklist.length; i++) {
-					if(this.isNotEar(linklist.getNode(i).point, node.prev.point, node.point, node.next.point, plane)) {
-						isEar = false;
-						break;
-					}
-				}
-				if(isEar) {
-					data.indices.push(node.prev.point_index, node.point_index, node.next.point_index);
-					data.point.push(node.prev.point, node.point, node.next.point);
-					if(node.normals) {					
-						data.normals.push(node.prev.normals, node.normals, node.next.normals);
-					}
-					if(node.colors){
-						data.colors.push(node.prev.colors, node.colors,	node.next.colors);
-					}
-					if(node.texCoords){
-						data.texCoords.push(node.prev.texCoords, node.texCoords, node.next.texCoords); 
-					}
-					linklist.deleteNode(node);
-				}
+		points = [];
+		
+		for (i = linklist.length-1; i >= 0; i--) {
+			node = linklist.getNode(i);
+			switch (plane) {
+				case "XY": { x = node.point.x; y = node.point.y; break; }
+				case "XZ": { x = node.point.z; y = node.point.x; break; }
+				default: { x = node.point.y; y = node.point.z; }
 			}
-			node = next;
-			isEar = true;
-			//abort if too long
-			if (Date.now() - t0 > timeout) { x3dom.debug.logError("Earclipping timed out."); break; }
+			points.push(y);
+			points.push(x);
+			mapped.indices.push(node.point_index);
+			mapped.point.push(node.point);
+			if (node.normals) mapped.normals.push(node.normals);
+			if (node.colors) mapped.colors.push(node.colors);
+			if (node.texCoords) mapped.texCoords.push(node.texCoords);
 		}
-		if(invers){	
-			data.indices = data.indices.reverse();
-			data.point = data.point.reverse();
-			data.normals = data.normals.reverse();
-			data.colors = data.colors.reverse();
-			data.texCoords = data.texCoords.reverse();
-		}
+		
+		var triangles = x3dom.EarCut.triangulate(points, null, 2);
+		data.indices = triangles.map(function(el) {return mapped.indices[el];}) ;
+		data.point = triangles.map(function(el) {return mapped.point[el];}) ;
+		data.normals = triangles.map(function(el) {return mapped.normals[el];}) ;
+		data.colors = triangles.map(function(el) {return mapped.colors[el];}) ;
+		data.texCoords = triangles.map(function(el) {return mapped.texCoords[el];}) ;
 		return data;
-	},
-	
-	isNotEar: function (ap1, tp1, tp2, tp3, plane) {
-		var b0, b1, b2, b3;
-		var ap1a, ap1b, tp1a, tp1b, tp2a, tp2b, tp3a, tp3b;
-		
-		if(plane == 'YZ') {
-			ap1a = ap1.y; ap1b = ap1.z;
-			tp1a = tp1.y; tp1b = tp1.z;
-			tp2a = tp2.y; tp2b = tp2.z;
-			tp3a = tp3.y; tp3b = tp3.z;
-		} else if(plane == 'XZ') {
-			ap1a = ap1.z; ap1b = ap1.x;
-			tp1a = tp1.z; tp1b = tp1.x;
-			tp2a = tp2.z; tp2b = tp2.x;
-			tp3a = tp3.z; tp3b = tp3.x;
-		} else {
-			ap1a = ap1.x; ap1b = ap1.y;
-			tp1a = tp1.x; tp1b = tp1.y;
-			tp2a = tp2.x; tp2b = tp2.y;
-			tp3a = tp3.x; tp3b = tp3.y;
-		}
-
-        b0 = ((tp2a - tp1a) * (tp3b - tp1b) - (tp3a - tp1a) * (tp2b - tp1b));
-        if (b0 != 0) {
-            b1 = (((tp2a - ap1a) * (tp3b - ap1b) - (tp3a - ap1a) * (tp2b - ap1b)) / b0);
-            b2 = (((tp3a - ap1a) * (tp1b - ap1b) - (tp1a - ap1a) * (tp3b - ap1b)) / b0);
-            b3 = 1 - b1 - b2;
-
-            return ((b1 > 0) && (b2 > 0) && (b3 > 0));
-        }
-        else {
-            return false;
-        }
-    },
-
-	isKonvex: function (p, p1, p2, plane) {
-		var pa, pb, p1a, p1b, p2a, p2b;
-		if(plane == 'YZ') {
-			pa = p.y; pb = p.z;
-			p1a = p1.y; p1b = p1.z;
-			p2a = p2.y; p2b = p2.z;
-		} else if(plane == 'XZ') {
-			pa = p.z; pb = p.x;
-			p1a = p1.z; p1b = p1.x;
-			p2a = p2.z; p2b = p2.x;
-		} else {
-			pa = p.x; pb = p.y;
-			p1a = p1.x; p1b = p1.y;
-			p2a = p2.x; p2b = p2.y;
-		}
-		
-		var l = ((p1a - pa) * (p2b - pb) - (p1b - pb) * (p2a - pa));
-        return (l >= 0);
-	},
+	}, 
 	
 	identifyPlane: function(p1, p2, p3) {
 		var v1x, v1y, v1z;
@@ -217,3 +104,606 @@ x3dom.EarClipping = {
 		}
 	}
 };
+
+x3dom.EarCut = {
+
+	triangulate: function mapEarcut (data, holes, dim) {
+		return earcut(data, holes, dim);
+
+/*
+The following code is
+Copyright (c) 2015, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+*/
+
+function earcut(data, holeIndices, dim) {
+
+    dim = dim || 2;
+
+    var hasHoles = holeIndices && holeIndices.length,
+        outerLen = hasHoles ? holeIndices[0] * dim : data.length,
+        clockwise = windingOrder(data, 0, outerLen, dim),
+        //outerNode = filterPoints(linkedList(data, 0, outerLen, dim, true, clockwise)),
+        outerNode = linkedList(data, 0, outerLen, dim, true, clockwise),
+        triangles = [];
+        
+	if (!outerNode) return triangles;
+
+    var minX, minY, maxX, maxY, x, y, size;
+
+    if (hasHoles) outerNode = eliminateHoles(data, holeIndices, outerNode, dim);
+
+    // if the shape is not too simple, we'll use z-order curve hash later; calculate polygon bbox
+    if (data.length > 80 * dim) {
+        minX = maxX = data[0];
+        minY = maxY = data[1];
+
+        for (var i = dim; i < outerLen; i += dim) {
+            x = data[i];
+            y = data[i + 1];
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+        }
+
+        // minX, minY and size are later used to transform coords into integers for z-order calculation
+        size = Math.max(maxX - minX, maxY - minY);
+    }
+
+    earcutLinked(outerNode, triangles, dim, minX, minY, size);
+		console.log(clockwise);
+    if (clockwise === false) {triangles.reverse();}
+    return triangles;
+}
+
+// calculate original winding order of a polygon ring
+function windingOrder(data, start, end, dim) {
+	var sum = 0;
+    for (i = start, j = end - dim; i < end; i += dim) {
+        sum += (data[j] - data[i]) * (data[i + 1] + data[j + 1]);
+        j = i;
+    }
+	//true for clockwise
+	return sum > 0;
+}
+
+// create a circular doubly linked list from polygon points in the specified winding order
+function linkedList(data, start, end, dim, clockwise, oclockwise) {
+    var i, j, last;
+
+    // link points into circular doubly-linked list in the specified winding order
+    if (clockwise === oclockwise) {
+        for (i = start; i < end; i += dim) last = insertNode(i, data[i], data[i + 1], last);
+    } else {
+        for (i = end - dim; i >= start; i -= dim) last = insertNode(i, data[i], data[i + 1], last);
+    }
+
+    return last;
+}
+// eliminate colinear or duplicate points
+function filterPoints(start, end) {
+    if (!start) return start;
+    if (!end) end = start;
+
+    var p = start,
+        again;
+    do {
+        again = false;
+
+        if (!p.steiner && (equals(p, p.next) || area(p.prev, p, p.next) === 0)) {
+            removeNode(p);
+            p = end = p.prev;
+            if (p === p.next) return null;
+            again = true;
+
+        } else {
+            p = p.next;
+        }
+    } while (again || p !== end);
+
+    return end;
+}
+
+// main ear slicing loop which triangulates a polygon (given as a linked list)
+function earcutLinked(ear, triangles, dim, minX, minY, size, pass) {
+    if (!ear) return;
+
+    // interlink polygon nodes in z-order
+    if (!pass && size) indexCurve(ear, minX, minY, size);
+
+    var stop = ear,
+        prev, next;
+
+    // iterate through ears, slicing them one by one
+    while (ear.prev !== ear.next) {
+        prev = ear.prev;
+        next = ear.next;
+
+        if (size ? isEarHashed(ear, minX, minY, size) : isEar(ear)) {
+            // cut off the triangle
+            triangles.push(prev.i / dim);
+            triangles.push(ear.i / dim);
+            triangles.push(next.i / dim);
+
+            removeNode(ear);
+
+            // skipping the next vertice leads to less sliver triangles
+            ear = next.next;
+            stop = next.next;
+
+            continue;
+        }
+
+        ear = next;
+
+        // if we looped through the whole remaining polygon and can't find any more ears
+        if (ear === stop) {
+            // try filtering points and slicing again
+            if (!pass) {
+                earcutLinked(filterPoints(ear), triangles, dim, minX, minY, size, 1);
+
+            // if this didn't work, try curing all small self-intersections locally
+            } else if (pass === 1) {
+                ear = cureLocalIntersections(ear, triangles, dim);
+                earcutLinked(ear, triangles, dim, minX, minY, size, 2);
+
+            // as a last resort, try splitting the remaining polygon into two
+            } else if (pass === 2) {
+                splitEarcut(ear, triangles, dim, minX, minY, size);
+            }
+
+            break;
+        }
+    }
+}
+
+// check whether a polygon node forms a valid ear with adjacent nodes
+function isEar(ear) {
+    var a = ear.prev,
+        b = ear,
+        c = ear.next;
+
+    if (area(a, b, c) >= 0) return false; // reflex, can't be an ear
+
+    // now make sure we don't have other points inside the potential ear
+    var p = ear.next.next;
+
+    while (p !== ear.prev) {
+        if (pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0) return false;
+        p = p.next;
+    }
+
+    return true;
+}
+
+function isEarHashed(ear, minX, minY, size) {
+    var a = ear.prev,
+        b = ear,
+        c = ear.next;
+
+    if (area(a, b, c) >= 0) return false; // reflex, can't be an ear
+
+    // triangle bbox; min & max are calculated like this for speed
+    var minTX = a.x < b.x ? (a.x < c.x ? a.x : c.x) : (b.x < c.x ? b.x : c.x),
+        minTY = a.y < b.y ? (a.y < c.y ? a.y : c.y) : (b.y < c.y ? b.y : c.y),
+        maxTX = a.x > b.x ? (a.x > c.x ? a.x : c.x) : (b.x > c.x ? b.x : c.x),
+        maxTY = a.y > b.y ? (a.y > c.y ? a.y : c.y) : (b.y > c.y ? b.y : c.y);
+
+    // z-order range for the current triangle bbox;
+    var minZ = zOrder(minTX, minTY, minX, minY, size),
+        maxZ = zOrder(maxTX, maxTY, minX, minY, size);
+
+    // first look for points inside the triangle in increasing z-order
+    var p = ear.nextZ;
+
+    while (p && p.z <= maxZ) {
+        if (p !== ear.prev && p !== ear.next &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0) return false;
+        p = p.nextZ;
+    }
+
+    // then look for points in decreasing z-order
+    p = ear.prevZ;
+
+    while (p && p.z >= minZ) {
+        if (p !== ear.prev && p !== ear.next &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0) return false;
+        p = p.prevZ;
+    }
+
+    return true;
+}
+
+// go through all polygon nodes and cure small local self-intersections
+function cureLocalIntersections(start, triangles, dim) {
+    var p = start;
+    do {
+        var a = p.prev,
+            b = p.next.next;
+
+        // a self-intersection where edge (v[i-1],v[i]) intersects (v[i+1],v[i+2])
+        if (intersects(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
+
+            triangles.push(a.i / dim);
+            triangles.push(p.i / dim);
+            triangles.push(b.i / dim);
+
+            // remove two nodes involved
+            removeNode(p);
+            removeNode(p.next);
+
+            p = start = b;
+        }
+        p = p.next;
+    } while (p !== start);
+
+    return p;
+}
+
+// try splitting polygon into two and triangulate them independently
+function splitEarcut(start, triangles, dim, minX, minY, size) {
+    // look for a valid diagonal that divides the polygon into two
+    var a = start;
+    do {
+        var b = a.next.next;
+        while (b !== a.prev) {
+            if (a.i !== b.i && isValidDiagonal(a, b)) {
+                // split the polygon in two by the diagonal
+                var c = splitPolygon(a, b);
+
+                // filter colinear points around the cuts
+                a = filterPoints(a, a.next);
+                c = filterPoints(c, c.next);
+
+                // run earcut on each half
+                earcutLinked(a, triangles, dim, minX, minY, size);
+                earcutLinked(c, triangles, dim, minX, minY, size);
+                return;
+            }
+            b = b.next;
+        }
+        a = a.next;
+    } while (a !== start);
+}
+
+// link every hole into the outer loop, producing a single-ring polygon without holes
+function eliminateHoles(data, holeIndices, outerNode, dim) {
+    var queue = [],
+        i, len, start, end, list;
+
+    for (i = 0, len = holeIndices.length; i < len; i++) {
+        start = holeIndices[i] * dim;
+        end = i < len - 1 ? holeIndices[i + 1] * dim : data.length;
+        list = linkedList(data, start, end, dim, false);
+        if (list === list.next) list.steiner = true;
+        //list = filterPoints(list);
+        //if (list)
+        queue.push(getLeftmost(list));
+    }
+
+    queue.sort(compareX);
+
+    // process holes from left to right
+    for (i = 0; i < queue.length; i++) {
+        eliminateHole(queue[i], outerNode);
+        outerNode = filterPoints(outerNode, outerNode.next);
+    }
+
+    return outerNode;
+}
+
+function compareX(a, b) {
+    return a.x - b.x;
+}
+
+// find a bridge between vertices that connects hole with an outer ring and and link it
+function eliminateHole(hole, outerNode) {
+    outerNode = findHoleBridge(hole, outerNode);
+    if (outerNode) {
+        var b = splitPolygon(outerNode, hole);
+        filterPoints(b, b.next);
+    }
+}
+
+// David Eberly's algorithm for finding a bridge between hole and outer polygon
+function findHoleBridge(hole, outerNode) {
+    var p = outerNode,
+        hx = hole.x,
+        hy = hole.y,
+        qx = -Infinity,
+        m;
+
+    // find a segment intersected by a ray from the hole's leftmost point to the left;
+    // segment's endpoint with lesser x will be potential connection point
+    do {
+        if (hy <= p.y && hy >= p.next.y) {
+            var x = p.x + (hy - p.y) * (p.next.x - p.x) / (p.next.y - p.y);
+            if (x <= hx && x > qx) {
+                qx = x;
+                m = p.x < p.next.x ? p : p.next;
+            }
+        }
+        p = p.next;
+    } while (p !== outerNode);
+
+    if (!m) return null;
+
+    // look for points inside the triangle of hole point, segment intersection and endpoint;
+    // if there are no points found, we have a valid connection;
+    // otherwise choose the point of the minimum angle with the ray as connection point
+
+    var stop = m,
+        tanMin = Infinity,
+        tan;
+
+    p = m.next;
+
+    while (p !== stop) {
+        if (hx >= p.x && p.x >= m.x &&
+                pointInTriangle(hy < m.y ? hx : qx, hy, m.x, m.y, hy < m.y ? qx : hx, hy, p.x, p.y)) {
+
+            tan = Math.abs(hy - p.y) / (hx - p.x); // tangential
+
+            if ((tan < tanMin || (tan === tanMin && p.x > m.x)) && locallyInside(p, hole)) {
+                m = p;
+                tanMin = tan;
+            }
+        }
+
+        p = p.next;
+    }
+
+    return m;
+}
+
+// interlink polygon nodes in z-order
+function indexCurve(start, minX, minY, size) {
+    var p = start;
+    do {
+        if (p.z === null) p.z = zOrder(p.x, p.y, minX, minY, size);
+        p.prevZ = p.prev;
+        p.nextZ = p.next;
+        p = p.next;
+    } while (p !== start);
+
+    p.prevZ.nextZ = null;
+    p.prevZ = null;
+
+    sortLinked(p);
+}
+
+// Simon Tatham's linked list merge sort algorithm
+// http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
+function sortLinked(list) {
+    var i, p, q, e, tail, numMerges, pSize, qSize,
+        inSize = 1;
+
+    do {
+        p = list;
+        list = null;
+        tail = null;
+        numMerges = 0;
+
+        while (p) {
+            numMerges++;
+            q = p;
+            pSize = 0;
+            for (i = 0; i < inSize; i++) {
+                pSize++;
+                q = q.nextZ;
+                if (!q) break;
+            }
+
+            qSize = inSize;
+
+            while (pSize > 0 || (qSize > 0 && q)) {
+
+                if (pSize === 0) {
+                    e = q;
+                    q = q.nextZ;
+                    qSize--;
+                } else if (qSize === 0 || !q) {
+                    e = p;
+                    p = p.nextZ;
+                    pSize--;
+                } else if (p.z <= q.z) {
+                    e = p;
+                    p = p.nextZ;
+                    pSize--;
+                } else {
+                    e = q;
+                    q = q.nextZ;
+                    qSize--;
+                }
+
+                if (tail) tail.nextZ = e;
+                else list = e;
+
+                e.prevZ = tail;
+                tail = e;
+            }
+
+            p = q;
+        }
+
+        tail.nextZ = null;
+        inSize *= 2;
+
+    } while (numMerges > 1);
+
+    return list;
+}
+
+// z-order of a point given coords and size of the data bounding box
+function zOrder(x, y, minX, minY, size) {
+    // coords are transformed into non-negative 15-bit integer range
+    x = 32767 * (x - minX) / size;
+    y = 32767 * (y - minY) / size;
+
+    x = (x | (x << 8)) & 0x00FF00FF;
+    x = (x | (x << 4)) & 0x0F0F0F0F;
+    x = (x | (x << 2)) & 0x33333333;
+    x = (x | (x << 1)) & 0x55555555;
+
+    y = (y | (y << 8)) & 0x00FF00FF;
+    y = (y | (y << 4)) & 0x0F0F0F0F;
+    y = (y | (y << 2)) & 0x33333333;
+    y = (y | (y << 1)) & 0x55555555;
+
+    return x | (y << 1);
+}
+
+// find the leftmost node of a polygon ring
+function getLeftmost(start) {
+    var p = start,
+        leftmost = start;
+    do {
+        if (p.x < leftmost.x) leftmost = p;
+        p = p.next;
+    } while (p !== start);
+
+    return leftmost;
+}
+
+// check if a point lies within a convex triangle
+function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
+    return (cx - px) * (ay - py) - (ax - px) * (cy - py) >= 0 &&
+           (ax - px) * (by - py) - (bx - px) * (ay - py) >= 0 &&
+           (bx - px) * (cy - py) - (cx - px) * (by - py) >= 0;
+}
+
+// check if a diagonal between two polygon nodes is valid (lies in polygon interior)
+function isValidDiagonal(a, b) {
+    return equals(a, b) || a.next.i !== b.i && a.prev.i !== b.i && !intersectsPolygon(a, b) &&
+           locallyInside(a, b) && locallyInside(b, a) && middleInside(a, b);
+}
+
+// signed area of a triangle
+function area(p, q, r) {
+    return (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+}
+
+// check if two points are equal
+function equals(p1, p2) {
+    return p1.x === p2.x && p1.y === p2.y;
+}
+
+// check if two segments intersect
+function intersects(p1, q1, p2, q2) {
+    return area(p1, q1, p2) > 0 !== area(p1, q1, q2) > 0 &&
+           area(p2, q2, p1) > 0 !== area(p2, q2, q1) > 0;
+}
+
+// check if a polygon diagonal intersects any polygon segments
+function intersectsPolygon(a, b) {
+    var p = a;
+    do {
+        if (p.i !== a.i && p.next.i !== a.i && p.i !== b.i && p.next.i !== b.i &&
+                intersects(p, p.next, a, b)) return true;
+        p = p.next;
+    } while (p !== a);
+
+    return false;
+}
+
+// check if a polygon diagonal is locally inside the polygon
+function locallyInside(a, b) {
+    return area(a.prev, a, a.next) < 0 ?
+        area(a, b, a.next) >= 0 && area(a, a.prev, b) >= 0 :
+        area(a, b, a.prev) < 0 || area(a, a.next, b) < 0;
+}
+
+// check if the middle point of a polygon diagonal is inside the polygon
+function middleInside(a, b) {
+    var p = a,
+        inside = false,
+        px = (a.x + b.x) / 2,
+        py = (a.y + b.y) / 2;
+    do {
+        if (((p.y > py) !== (p.next.y > py)) && (px < (p.next.x - p.x) * (py - p.y) / (p.next.y - p.y) + p.x))
+            inside = !inside;
+        p = p.next;
+    } while (p !== a);
+
+    return inside;
+}
+
+// link two polygon vertices with a bridge; if the vertices belong to the same ring, it splits polygon into two;
+// if one belongs to the outer ring and another to a hole, it merges it into a single ring
+function splitPolygon(a, b) {
+    var a2 = new Node(a.i, a.x, a.y),
+        b2 = new Node(b.i, b.x, b.y),
+        an = a.next,
+        bp = b.prev;
+
+    a.next = b;
+    b.prev = a;
+
+    a2.next = an;
+    an.prev = a2;
+
+    b2.next = a2;
+    a2.prev = b2;
+
+    bp.next = b2;
+    b2.prev = bp;
+
+    return b2;
+}
+
+// create a node and optionally link it with previous one (in a circular doubly linked list)
+function insertNode(i, x, y, last) {
+    var p = new Node(i, x, y);
+
+    if (!last) {
+        p.prev = p;
+        p.next = p;
+
+    } else {
+        p.next = last.next;
+        p.prev = last;
+        last.next.prev = p;
+        last.next = p;
+    }
+    return p;
+}
+
+function removeNode(p) {
+    p.next.prev = p.prev;
+    p.prev.next = p.next;
+
+    if (p.prevZ) p.prevZ.nextZ = p.nextZ;
+    if (p.nextZ) p.nextZ.prevZ = p.prevZ;
+}
+
+function Node(i, x, y) {
+    // vertice index in coordinates array
+    this.i = i;
+
+    // vertex coordinates
+    this.x = x;
+    this.y = y;
+
+    // previous and next vertice nodes in a polygon ring
+    this.prev = null;
+    this.next = null;
+
+    // z-order curve value
+    this.z = null;
+
+    // previous and next nodes in z-order
+    this.prevZ = null;
+    this.nextZ = null;
+
+    // indicates whether this is a steiner point
+    this.steiner = false;
+}
+}
+}

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -126,8 +126,9 @@ function earcut(data, holeIndices, dim) {
 
     var hasHoles = holeIndices && holeIndices.length,
         outerLen = hasHoles ? holeIndices[0] * dim : data.length,
-        clockwise = windingOrder(data, 0, outerLen, dim),
         //outerNode = filterPoints(linkedList(data, 0, outerLen, dim, true, clockwise)),
+        //AP: remember winding order
+        clockwise = windingOrder(data, 0, outerLen, dim),
         outerNode = linkedList(data, 0, outerLen, dim, true, clockwise),
         triangles = [];
         
@@ -155,11 +156,13 @@ function earcut(data, holeIndices, dim) {
         size = Math.max(maxX - minX, maxY - minY);
     }
 	earcutLinked(outerNode, triangles, dim, minX, minY, size);
+	//AP: preserve winding order
 	if (clockwise === false) {triangles.reverse();}
 	return triangles;
 }
 
 // calculate original winding order of a polygon ring
+// AP: separated to get original winding order
 function windingOrder(data, start, end, dim) {
 	var sum = 0;
     for (i = start, j = end - dim; i < end; i += dim) {
@@ -171,6 +174,7 @@ function windingOrder(data, start, end, dim) {
 }
 
 // create a circular doubly linked list from polygon points in the specified winding order
+// AP: oclockwise = original winding order
 function linkedList(data, start, end, dim, clockwise, oclockwise) {
     var i, j, last;
 

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -15,7 +15,6 @@ x3dom.EarClipping = {
 		
 		var node = linklist.first.next;
 		var plane = this.identifyPlane(node.prev.point, node.point, node.next.point);
-		console.log(plane);
 		var i, points, x, y;
 		points = [];
 		point_indexes = [];

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -31,7 +31,7 @@ x3dom.EarClipping = {
 			point_indexes.push(node.point_index);
 		}
 		var triangles = x3dom.EarCut.triangulate(points, null, 2);
-		triangles = triangles.map(function(el) {return point_indexes[el];}) ;
+		triangles = triangles.map(function(m) {return point_indexes[m];}) ;
 		return triangles;
 	},
 
@@ -53,7 +53,6 @@ x3dom.EarClipping = {
 		
 		points = [];
 		
-		//for (i = linklist.length-1; i >= 0; i--) {
 		for (i = 0; i < linklist.length; i++) {
 			node = linklist.getNode(i);
 			switch (plane) {
@@ -71,11 +70,11 @@ x3dom.EarClipping = {
 		}
 		
 		var triangles = x3dom.EarCut.triangulate(points, null, 2);
-		data.indices = triangles.map(function(el) {return mapped.indices[el];}) ;
-		data.point = triangles.map(function(el) {return mapped.point[el];}) ;
-		data.normals = triangles.map(function(el) {return mapped.normals[el];}) ;
-		data.colors = triangles.map(function(el) {return mapped.colors[el];}) ;
-		data.texCoords = triangles.map(function(el) {return mapped.texCoords[el];}) ;
+		data.indices = triangles.map(function(m) {return mapped.indices[m];}) ;
+		data.point = triangles.map(function(m) {return mapped.point[m];}) ;
+		if (node.normals) data.normals = triangles.map(function(m) {return mapped.normals[m];}) ;
+		if (node.colors) data.colors = triangles.map(function(m) {return mapped.colors[m];}) ;
+		if (node.texCoords) data.texCoords = triangles.map(function(m) {return mapped.texCoords[m];}) ;
 		return data;
 	}, 
 	

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -105,6 +105,7 @@ x3dom.EarClipping = {
 };
 
 //TODO: adjust to directly use x3dom linked list
+//      move to separate file
 x3dom.EarCut = {
 
 	triangulate: function mapEarcut (data, holes, dim) {

--- a/src/util/EarClipping.js
+++ b/src/util/EarClipping.js
@@ -105,6 +105,7 @@ x3dom.EarClipping = {
 	}
 };
 
+//TODO: adjust to directly use x3dom linked list
 x3dom.EarCut = {
 
 	triangulate: function mapEarcut (data, holes, dim) {
@@ -153,11 +154,9 @@ function earcut(data, holeIndices, dim) {
         // minX, minY and size are later used to transform coords into integers for z-order calculation
         size = Math.max(maxX - minX, maxY - minY);
     }
-
-    earcutLinked(outerNode, triangles, dim, minX, minY, size);
-		console.log(clockwise);
-    if (clockwise === false) {triangles.reverse();}
-    return triangles;
+	earcutLinked(outerNode, triangles, dim, minX, minY, size);
+	if (clockwise === false) {triangles.reverse();}
+	return triangles;
 }
 
 // calculate original winding order of a polygon ring


### PR DESCRIPTION
This PR replaces the earclipping algorithm with a more efficient earclipping library available here:
https://github.com/mapbox/earcut
The main advantage is handling of corner cases and large polygons. 
The dedicated library is compact and included directly in EarClipping.js but it could be moved to a separate file.
There is some required remapping of input and output to and from the library which could be optimized by directly using the provided x3dom linkedlist.
The library also deals with holes in polygons if needed elsewhere (fonts?) at some point.
This user script allows for testing:
https://gist.githubusercontent.com/andreasplesch/42d6405d0de8cc2472b8/raw/x3domEarcut.user.js
