### PR TITLE
Change shader keys

### DIFF
--- a/src/nodes/Shaders/ComposedShader.js
+++ b/src/nodes/Shaders/ComposedShader.js
@@ -82,12 +82,13 @@ x3dom.registerNodeType(
         {
            /**
             * Return `url` in canonical form
-            * @param {string} url
+            * @param {string} A relative or absolute URL
             */
             canonicalUrl: function( url )
             {
-              // warxing do this by using "this._namespace.GetURL"
-              // TODO: Convert to canonical form
+              // TODO: Convert to canonical form, preferably absolute form. Not sure of a fast
+              // way to convert a url to absolute that doesn't involve bringing in another library
+              // or using non-general hacks that involve creating and then deleting DOM elements.
               return url;
             },
             

--- a/src/nodes/Shaders/ComposedShader.js
+++ b/src/nodes/Shaders/ComposedShader.js
@@ -117,20 +117,7 @@ x3dom.registerNodeType(
                         fragmentUrl = this._fragment.shaderUrl;
                         numFragmentParts++;
                     }
-                }   
-                
-                if( numVertexParts != 1 )
-                {
-                    x3dom.debug.logError ( 'ComposedShader element has ' 
-                      + numVertexParts 
-                      + ' vertex shader parts but should have only one.' );                  
-                }
-                if( numFragmentParts != 1 )
-                {
-                    x3dom.debug.logError ( 'ComposedShader element has ' 
-                      + numFragmentParts 
-                      + ' fragment shader parts but should have only one.' );                  
-                }                
+                }                                
 
                 this._id = 'ComposedShaderID: ' + this.canonicalUrl( vertexUrl ) + ' - ' + this.canonicalUrl( fragmentUrl );              
             },

--- a/src/nodes/Shaders/ShaderPart.js
+++ b/src/nodes/Shaders/ShaderPart.js
@@ -126,7 +126,7 @@ x3dom.registerNodeType(
                 this.handleNewUrl();
                 // else hope that url field was already set somehow
 
-                Array.forEach(this._parentNodes, function (shader) {                  
+                Array.forEach(this._parentNodes, function (shader) {
                     shader.nodeChanged();
                 });
             },

--- a/src/nodes/Shaders/ShaderPart.js
+++ b/src/nodes/Shaders/ShaderPart.js
@@ -50,11 +50,12 @@ x3dom.registerNodeType(
              */
             this.addField_SFString(ctx, 'type', "VERTEX");
             
+            // TODO: At the moment, this might be absolute or relative. It would be nicer if 
+            // it was always absolute.
             /**
-             * The URL of the shader.
+             * The URL of the shader. At the moment, this could be an absolute or relative URL,           
              * @type {string}
              */
-             // warxing this should be absolute... right?
             this.shaderUrl = '';
             
             this._id = (ctx && ctx.xmlNode && ctx.xmlNode.id != "") ?

--- a/src/nodes/Shaders/ShaderPart.js
+++ b/src/nodes/Shaders/ShaderPart.js
@@ -49,7 +49,14 @@ x3dom.registerNodeType(
              * @instance
              */
             this.addField_SFString(ctx, 'type', "VERTEX");
-
+            
+            /**
+             * The URL of the shader.
+             * @type {string}
+             */
+             // warxing this should be absolute... right?
+            this.shaderUrl = '';
+            
             this._id = (ctx && ctx.xmlNode && ctx.xmlNode.id != "") ?
                 ctx.xmlNode.id : ++x3dom.nodeTypes.Shape.shaderPartID;
 
@@ -58,8 +65,12 @@ x3dom.registerNodeType(
                                "Unknown shader part type!");
         },
         {
-            nodeChanged: function()
-            {
+          
+            /**
+             * Store the URL and fetch the shader code located at this location.
+             */
+            handleNewUrl: function()
+            {      
                 var ctx = {};
                 ctx.xmlNode = this._xmlNode;
 
@@ -69,8 +80,13 @@ x3dom.registerNodeType(
 
                     if (that._vf.url.length && that._vf.url[0].indexOf('\n') == -1)
                     {
+                        // Store the actual URL.   
+                        var url = that._nameSpace.getURL(that._vf.url[0]);
+                        that.shaderUrl = url;
+                      
+                        // Fetch the shader text.
                         var xhr = new XMLHttpRequest();
-                        xhr.open("GET", that._nameSpace.getURL(that._vf.url[0]), false);
+                        xhr.open("GET", url, false);
                         xhr.onload = function() {
                             that._vf.url = new x3dom.fields.MFString( [] );
                             that._vf.url.push(xhr.response);
@@ -101,10 +117,15 @@ x3dom.registerNodeType(
                             } );
                         }
                     }
-                }
+                }              
+            },
+          
+            nodeChanged: function()
+            {     
+                this.handleNewUrl();
                 // else hope that url field was already set somehow
 
-                Array.forEach(this._parentNodes, function (shader) {
+                Array.forEach(this._parentNodes, function (shader) {                  
                     shader.nodeChanged();
                 });
             },
@@ -112,6 +133,7 @@ x3dom.registerNodeType(
             fieldChanged: function(fieldName)
             {
                 if (fieldName === "url") {
+                    this.handleNewUrl();
                     Array.forEach(this._parentNodes, function (shader) {
                         shader.fieldChanged("url");
                     });


### PR DESCRIPTION
We changed how Cache stores shaders. Now Cache keys shaders by the "url" values from their ShaderParts rather than the "id" values from their ShaderParts. This makes it possible to change which shader a ComposedShader represents by directly modifying the "url" fields of its two ShaderParts.