### PR TITLE
Added a 1.0, 1.0 polygon offset to apply to all "filled" polygons.

### DIFF
--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -2640,6 +2640,8 @@ x3dom.gfx_webgl = (function () {
                     gl.drawArrays(s_gl.primType, 0, s_gl.positions[q].length / 3);
                 }
                 else {
+                    gl.enable( gl.POLYGON_OFFSET_FILL );
+                    gl.polygonOffset( 1.0, 1.0 )
                     gl.drawElements(s_gl.primType, s_gl.indexes[q].length, s_gl.indexType, 0);
                 }
             }


### PR DESCRIPTION
This has the effect that any lines or points which are drawn on top of
triangles will not have stitching artifacts.