### PR TITLE
Plugins API for X3DOM

### DIFF
--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -406,8 +406,29 @@ x3dom.gfx_webgl = (function () {
                                 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(szArr), gl.STATIC_DRAW);
                             }
 
-                            shape._dirty.specialAttribs = false;
                         }
+                        // Special attribs is FloatVertexAttribute
+                        var AttribNodes = geoNode._mesh._dynamicFields;
+                        var attribNode, attribName;
+                        for (attribName in  AttribNodes) {
+                            attribNode = AttribNodes[attribName];
+                            if (attribNode !== undefined && attribNode.value.length) {
+                                // Remove old attribute buffer
+                                var attribs = new Float32Array(attribNode.value);
+                                var attribWebGLNode = shape._webgl.dynamicFields.find(
+                                    function(a){ return a.name == attribName;});
+                                if (attribWebGLNode.buf.toString() == "[object WebGLBuffer]")
+                                    gl.deleteBuffer(attribWebGLNode.buf);
+                                gl.deleteBuffer(attribWebGLNode.buf);
+                                attribWebGLNode.buf = gl.createBuffer();
+
+                                gl.bindBuffer(gl.ARRAY_BUFFER, attribWebGLNode.buf);
+                                gl.bufferData(gl.ARRAY_BUFFER, attribs, gl.STATIC_DRAW);
+
+                                attribs = null;
+                            }
+                        }
+                        shape._dirty.specialAttribs = false;
                         // Maybe other special attribs here, though e.g. AFAIK only BG (which not handled here) has ids.
                     }
                 }

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -417,6 +417,7 @@ x3dom.gfx_webgl = (function () {
                                 var attribs = new Float32Array(attribNode.value);
                                 var attribWebGLNode = shape._webgl.dynamicFields.find(
                                     function(a){ return a.name == attribName;});
+                                if (!attribWebGLNode) continue;
                                 if (attribWebGLNode.buf.toString() == "[object WebGLBuffer]")
                                     gl.deleteBuffer(attribWebGLNode.buf);
                                 gl.deleteBuffer(attribWebGLNode.buf);

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -2062,7 +2062,7 @@ x3dom.gfx_webgl = (function () {
         for (i=0; i<n ; i++){
             node = s_geo._cf.customAttributes.nodes[i];
             for (j=0; j < node._cf.uniforms.nodes.length; j++){
-                uniform = node._cf.uniforms.nodes[i];
+                uniform = node._cf.uniforms.nodes[j];
                 name = uniform._vf.name;
                 sp[uniform._vf.name] = uniform._vf.value;
             }

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -2057,6 +2057,18 @@ x3dom.gfx_webgl = (function () {
             sp.bgPrecisionNorMax = 1;
         }
 
+        var n = s_geo._cf.customAttributes.nodes.length;
+        var node,j, uniform, name;
+        for (i=0; i<n ; i++){
+            node = s_geo._cf.customAttributes.nodes[i];
+            for (j=0; j < node._cf.uniforms.nodes.length; j++){
+                uniform = node._cf.uniforms.nodes[i];
+                name = uniform._vf.name;
+                sp[uniform._vf.name] = uniform._vf.value;
+            }
+        }
+
+
         if (s_gl.imageGeometry != 0) {
             sp.IG_bboxMin = s_geo.getMin().toGL();
             sp.IG_bboxMax = s_geo.getMax().toGL();

--- a/src/nodes/CADGeometry/IndexedQuadSet.js
+++ b/src/nodes/CADGeometry/IndexedQuadSet.js
@@ -314,6 +314,28 @@ x3dom.registerNodeType(
                         node._dirty.texcoords = true;
                     });
                 }
+                else if (fieldName.startsWith("attrib"))
+                {
+                    var attrName = fieldName.slice(7);
+                    var attrNode = this._cf.attrib.nodes.find(
+                            function (a) {return a._vf.name == attrName;}
+                    );
+                    var attr_data= attrNode._vf.value;
+                    var attr_numComp= attrNode._vf.numComponents;
+
+                    this._mesh._dynamicFields[attrName].value = [];
+                    this._mesh._dynamicFields[attrName].numComponents = attr_numComp;
+                    indexes = this._vf.index;
+                    for (var i=0; i < indexes.length; ++i) {
+                        for (var j=0; j < attr_numComp;j++ ) {
+                            this._mesh._dynamicFields[attrName].value.push(
+                                attr_data[attr_numComp*indexes[i]+j]);
+                        }
+                    }
+                    Array.forEach(this._parentNodes, function (node) {
+                        node._dirty.specialAttribs = true;
+                    });
+                }
             }
         }
     )

--- a/src/nodes/CADGeometry/QuadSet.js
+++ b/src/nodes/CADGeometry/QuadSet.js
@@ -292,6 +292,22 @@ x3dom.registerNodeType(
                         node._dirty.texcoords = true;
                     });
                 }
+                else if (fieldName.startsWith("attrib"))
+                {
+                    var attrName = fieldName.slice(7);
+                    var attrNode = this._cf.attrib.nodes.find(
+                            function (a) {return a._vf.name == attrName;}
+                    );
+                    var attr_data= attrNode._vf.value;
+                    var attr_numComp= attrNode._vf.numComponents;
+
+                    this._mesh._dynamicFields[attrName].numComponents = attr_numComp;
+                    this._mesh._dynamicFields[attrName].value= attr_data.toGL();
+
+                    Array.forEach(this._parentNodes, function (node) {
+                        node._dirty.specialAttribs = true;
+                    });
+                }
             }
         }
     )

--- a/src/nodes/Geometry3D/IndexedFaceSet.js
+++ b/src/nodes/Geometry3D/IndexedFaceSet.js
@@ -865,8 +865,6 @@ x3dom.registerNodeType(
                                     else if (hasColorInd && !colPerVert) { c2 = +colorInd[faceCnt]; }
                                     else if (colPerVert) { c2 = p2; }
                                     else { c2 = faceCnt; }
-                                    t = 3;
-
                                     //this._mesh._indices[0].push(cnt++, cnt++, cnt++);
 
                                     this._mesh._positions[0].push(positions[p0].x);
@@ -932,111 +930,8 @@ x3dom.registerNodeType(
                                             this._mesh._texCoords[0].push(texCoords[t2].z);
                                         }
                                     }
-
-                                    //faceCnt++;
-                                    break;
-                                case 3:
                                     p1 = p2;
                                     t1 = t2;
-                                    if (normPerVert) {
-                                        n1 = n2;
-                                    }
-                                    if (colPerVert) {
-                                        c1 = c2;
-                                    }
-                                    p2 = +indexes[i];
-
-                                    if (hasNormalInd && normPerVert) {
-                                        n2 = +normalInd[i];
-                                    } else if (hasNormalInd && !normPerVert) {
-                                        /*n2 = +normalInd[faceCnt];*/
-                                    } else if (normPerVert) {
-                                        n2 = p2;
-                                    } else {
-                                        n2 = faceCnt;
-                                    }
-
-                                    if (hasTexCoordInd) {
-                                        t2 = +texCoordInd[i];
-                                    } else {
-                                        t2 = p2;
-                                    }
-
-                                    if (hasColorInd && colPerVert) {
-                                        c2 = +colorInd[i];
-                                    } else if (hasColorInd && !colPerVert) {
-                                        /*c2 = +colorInd[faceCnt];*/
-                                    } else if (colPerVert) {
-                                        c2 = p2;
-                                    } else {
-                                        c2 = faceCnt;
-                                    }
-
-                                    //this._mesh._indices[0].push(cnt++, cnt++, cnt++);
-
-                                    this._mesh._positions[0].push(positions[p0].x);
-                                    this._mesh._positions[0].push(positions[p0].y);
-                                    this._mesh._positions[0].push(positions[p0].z);
-                                    this._mesh._positions[0].push(positions[p1].x);
-                                    this._mesh._positions[0].push(positions[p1].y);
-                                    this._mesh._positions[0].push(positions[p1].z);
-                                    this._mesh._positions[0].push(positions[p2].x);
-                                    this._mesh._positions[0].push(positions[p2].y);
-                                    this._mesh._positions[0].push(positions[p2].z);
-
-                                    if (hasNormal) {
-                                        this._mesh._normals[0].push(normals[n0].x);
-                                        this._mesh._normals[0].push(normals[n0].y);
-                                        this._mesh._normals[0].push(normals[n0].z);
-                                        this._mesh._normals[0].push(normals[n1].x);
-                                        this._mesh._normals[0].push(normals[n1].y);
-                                        this._mesh._normals[0].push(normals[n1].z);
-                                        this._mesh._normals[0].push(normals[n2].x);
-                                        this._mesh._normals[0].push(normals[n2].y);
-                                        this._mesh._normals[0].push(normals[n2].z);
-                                    }
-                                    //else {
-                                    this._mesh._multiIndIndices.push(p0, p1, p2);
-                                    //}
-
-                                    if (hasColor) {
-                                        this._mesh._colors[0].push(colors[c0].r);
-                                        this._mesh._colors[0].push(colors[c0].g);
-                                        this._mesh._colors[0].push(colors[c0].b);
-                                        if (numColComponents === 4) {
-                                            this._mesh._colors[0].push(colors[c0].a);
-                                        }
-                                        this._mesh._colors[0].push(colors[c1].r);
-                                        this._mesh._colors[0].push(colors[c1].g);
-                                        this._mesh._colors[0].push(colors[c1].b);
-                                        if (numColComponents === 4) {
-                                            this._mesh._colors[0].push(colors[c1].a);
-                                        }
-                                        this._mesh._colors[0].push(colors[c2].r);
-                                        this._mesh._colors[0].push(colors[c2].g);
-                                        this._mesh._colors[0].push(colors[c2].b);
-                                        if (numColComponents === 4) {
-                                            this._mesh._colors[0].push(colors[c2].a);
-                                        }
-                                    }
-
-                                    if (hasTexCoord) {
-                                        this._mesh._texCoords[0].push(texCoords[t0].x);
-                                        this._mesh._texCoords[0].push(texCoords[t0].y);
-                                        if (numTexComponents === 3) {
-                                            this._mesh._texCoords[0].push(texCoords[t0].z);
-                                        }
-                                        this._mesh._texCoords[0].push(texCoords[t1].x);
-                                        this._mesh._texCoords[0].push(texCoords[t1].y);
-                                        if (numTexComponents === 3) {
-                                            this._mesh._texCoords[0].push(texCoords[t1].z);
-                                        }
-                                        this._mesh._texCoords[0].push(texCoords[t2].x);
-                                        this._mesh._texCoords[0].push(texCoords[t2].y);
-                                        if (numTexComponents === 3) {
-                                            this._mesh._texCoords[0].push(texCoords[t2].z);
-                                        }
-                                    }
 
                                     //faceCnt++;
                                     break;

--- a/src/nodes/Geometry3D/IndexedFaceSet.js
+++ b/src/nodes/Geometry3D/IndexedFaceSet.js
@@ -955,6 +955,12 @@ x3dom.registerNodeType(
                                     }
                                     p1 = p2;
                                     t1 = t2;
+                                    if (normPerVert) {
+                                        n1 = n2;
+                                    }
+                                    if (colPerVert) {
+                                        c1 = c2;
+                                    }
 
                                     //faceCnt++;
                                     break;

--- a/src/nodes/Rendering/CustomAttributeNode.js
+++ b/src/nodes/Rendering/CustomAttributeNode.js
@@ -59,6 +59,70 @@ x3dom.registerNodeType(
              */
             this.addField_SFString(ctx, 'fragmentShaderPartMain', "");
 
+        },{
+            get: function(name){
+                return this._vf[name];
+            },
+            addUniform: function(name, value , type){
+                if  (this._cf.uniforms == undefined)
+                    this._cf.uniforms = new x3dom.fields.MFNode(x3dom.nodeTypes.Uniform);
+                var uniform = new x3dom.nodeTypes.Uniform();
+                uniform._vf.name = name;
+                uniform._vf.type = type;
+                uniform._vf.value = value;
+                this._cf.uniforms.nodes.push(uniform);
+            },
+            addVarying: function(name, type){
+                if  (this._cf.varyings == undefined)
+                    this._cf.varyings = new x3dom.fields.MFNode(x3dom.nodeTypes.Varying);
+                var varying = new x3dom.nodeTypes.Varying();
+                varying._vf.name = name;
+                varying._vf.type = type;
+                this._cf.varyings.nodes.push(varying);
+            },
+            addVertexShaderPart(string){
+                this._vf.vertexShaderPartMain = string;
+            },
+            addFragmentShaderPart(string){
+                this._vf.fragmentShaderPartMain = string;
+            },
+            attributeNameChanged(name){
+                var dataName = this._vf[name];
+                var i, n, shape, sp, nbAttr;
+                Array.forEach(this._parentNodes, function (geonode) {
+                    for (i=0, n = geonode._parentNodes.length; i<n; i++) {
+                        shape = geonode._parentNodes[i];
+                        shape._dirty.shader = true;
+                        sp = shape._webgl.shader;
+                        // If the shader program don't have the webgl buffer: create it
+                        if (!sp[geonode._cf.threshold.node._vf.dataName]) {
+                            setUpWebglBuffer(shape, geonode);
+                        }
+                    }
+                });
+            },
+            updateUniform(fieldName, uniformName){
+                var node = this._cf.uniforms.nodes.find(
+                    function(a){return a._vf.name == uniformName;}
+                );
+                if (node){
+                    node._vf.value = this._vf[fieldName];
+                    node.fieldChanged("value");
+                }
+            }
         }
     )
 );
+
+function setUpWebglBuffer(shape, geonode){
+    var x3dElem = document.getElementsByTagName("x3d")[0];
+    var gl = x3dElem.runtime.canvas.gl.ctx3d;
+    var attribName = geonode._cf.threshold.node._vf.dataName;
+    var attribs = new Float32Array(
+        geonode._mesh._dynamicFields[attribName].value);
+    var attribWebGLNode = shape._webgl.dynamicFields.find(
+        function(a){ return a.name == attribName;});
+    attribWebGLNode.buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, attribWebGLNode.buf);
+    gl.bufferData(gl.ARRAY_BUFFER, attribs, gl.STATIC_DRAW);
+}

--- a/src/nodes/Rendering/CustomAttributeNode.js
+++ b/src/nodes/Rendering/CustomAttributeNode.js
@@ -36,15 +36,9 @@ x3dom.registerNodeType(
              */
             this.addField_MFNode('uniforms', x3dom.nodeTypes.Uniform);
 
-            /**
-             * Part of the vertex shaders to set the attributes and varing
-             * @var {x3dom.fields.SFString} type
-             * @memberof x3dom.nodeTypes.Field
-             * @initvalue ""
-             * @field x3dom
-             * @instance
-             */
-            this.addField_SFString(ctx, 'vertexShaderPartInit', "");
+
+            this.addField_MFNode('varyings', x3dom.nodeTypes.Varying);
+
             /**
              * Part of the vertex shaders main
              * @var {x3dom.fields.SFString} type
@@ -54,15 +48,7 @@ x3dom.registerNodeType(
              * @instance
              */
             this.addField_SFString(ctx, 'vertexShaderPartMain', "");
-            /**
-             * Part of the fragment shaders to set the attributes and varing
-             * @var {x3dom.fields.SFString} type
-             * @memberof x3dom.nodeTypes.Field
-             * @initvalue ""
-             * @field x3dom
-             * @instance
-             */
-            this.addField_SFString(ctx, 'fragmentShaderPartInit', "");
+
             /**
              * Part of the fragment shaders main
              * @var {x3dom.fields.SFString} type

--- a/src/nodes/Rendering/CustomAttributeNode.js
+++ b/src/nodes/Rendering/CustomAttributeNode.js
@@ -1,0 +1,78 @@
+/** @namespace x3dom.nodeTypes */
+/*
+ * X3DOM JavaScript Library
+ * http://www.x3dom.org
+ *
+ * (C)2009 Fraunhofer IGD, Darmstadt, Germany
+ * Dual licensed under the MIT and GPL
+ */
+/* ### CustomAttributeNode ### */
+x3dom.registerNodeType(
+    "CustomAttributeNode",
+    "Rendering",
+    defineClass(x3dom.nodeTypes.X3DGeometricPropertyNode,
+
+        /**
+         * Constructor for CustomAttributNode
+         * @constructs x3dom.nodeTypes.CustomAttributNode
+         * @x3d 3.2
+         * @component Rendering
+         * @status ?
+         * @extends x3dom.nodeTypes.X3DChildNode
+         * @param {Object} [ctx=null] - context object, containing initial settings like namespace
+         * @classdesc The threshold field allows to hide part of the mesh.
+         * The hidden part is when the given is are higer or lower
+         * than a given value
+         */
+        function (ctx) {
+            x3dom.nodeTypes.CustomAttributeNode.superClass.call(this, ctx);
+            /**
+             * List of uniforms for the shaders
+             * @var {x3dom.fields.MFNode} uniforms
+             * @memberof x3dom.nodeTypes.X3DComposedGeometryNode
+             * @initvalue x3dom.nodeTypes.X3DVertexAttributeNode
+             * @field x3dom
+             * @instance
+             */
+            this.addField_MFNode('uniforms', x3dom.nodeTypes.Uniform);
+
+            /**
+             * Part of the vertex shaders to set the attributes and varing
+             * @var {x3dom.fields.SFString} type
+             * @memberof x3dom.nodeTypes.Field
+             * @initvalue ""
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFString(ctx, 'vertexShaderPartInit', "");
+            /**
+             * Part of the vertex shaders main
+             * @var {x3dom.fields.SFString} type
+             * @memberof x3dom.nodeTypes.Field
+             * @initvalue ""
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFString(ctx, 'vertexShaderPartMain', "");
+            /**
+             * Part of the fragment shaders to set the attributes and varing
+             * @var {x3dom.fields.SFString} type
+             * @memberof x3dom.nodeTypes.Field
+             * @initvalue ""
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFString(ctx, 'fragmentShaderPartInit', "");
+            /**
+             * Part of the fragment shaders main
+             * @var {x3dom.fields.SFString} type
+             * @memberof x3dom.nodeTypes.Field
+             * @initvalue ""
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFString(ctx, 'fragmentShaderPartMain', "");
+
+        }
+    )
+);

--- a/src/nodes/Rendering/IndexedTriangleSet.js
+++ b/src/nodes/Rendering/IndexedTriangleSet.js
@@ -440,6 +440,29 @@ x3dom.registerNodeType(
                         node._dirty.texcoords = true;
                     });
                 }
+                else if (fieldName.startsWith("attrib"))
+                {
+                    var attrName = fieldName.slice(7);
+                    var attrNode = this._cf.attrib.nodes.find(
+                            function (a) {return a._vf.name == attrName;}
+                    );
+                    var attr_data= attrNode._vf.value;
+                    var attr_numComp= attrNode._vf.numComponents;
+
+                    this._mesh._dynamicFields[attrName].value = [];
+                    this._mesh._dynamicFields[attrName].numComponents = attr_numComp;
+                    indexes = this._vf.index;
+                    for (i=0; i < indexes.length; ++i) {
+                        for (var j=0; j < attr_numComp;j++ ) {
+                            this._mesh._dynamicFields[attrName].value.push(
+                                attr_data[attr_numComp* indexes[i]+j]);
+                        }
+                    }
+
+                    Array.forEach(this._parentNodes, function (node) {
+                        node._dirty.specialAttribs = true;
+                    });
+                }
                 // TODO: index
             }
         }

--- a/src/nodes/Rendering/TriangleSet.js
+++ b/src/nodes/Rendering/TriangleSet.js
@@ -33,6 +33,7 @@ x3dom.registerNodeType(
         {
             _buildGeometry: function()
             {
+                this.handleAttribs();
                 var colPerVert = this._vf.colorPerVertex;
                 var normPerVert = this._vf.normalPerVertex;
 
@@ -198,6 +199,14 @@ x3dom.registerNodeType(
 
                     Array.forEach(this._parentNodes, function (node) {
                         node._dirty.texcoords = true;
+                    });
+                }
+                else if (fieldName.startsWith("attrib"))
+                {
+                    this._buildGeometry();
+
+                    Array.forEach(this._parentNodes, function (node) {
+                        node._dirty.specialAttribs = true;
                     });
                 }
             }

--- a/src/nodes/Rendering/X3DComposedGeometryNode.js
+++ b/src/nodes/Rendering/X3DComposedGeometryNode.js
@@ -71,6 +71,16 @@ x3dom.registerNodeType(
              */
             this.addField_MFNode('attrib', x3dom.nodeTypes.X3DVertexAttributeNode);
 
+            /**
+             * If the custom nodes
+             * @var {x3dom.fields.MFNode} attrib
+             * @memberof x3dom.nodeTypes.X3DComposedGeometryNode
+             * @initvalue x3dom.nodeTypes.X3DVertexAttributeNode
+             * @field x3dom
+             * @instance
+             */
+            this.addField_MFNode('customAttributes', x3dom.nodeTypes.CustomAttributeNode);
+
 
             /**
              * Contains a Coordinate node.

--- a/src/nodes/Shaders/FloatVertexAttribute.js
+++ b/src/nodes/Shaders/FloatVertexAttribute.js
@@ -53,6 +53,16 @@ x3dom.registerNodeType(
              */
             this.addField_MFFloat(ctx, 'value', []);
         
+        },
+        {
+            fieldChanged: function (fieldName) {
+                var that = this;
+                if (fieldName == "value" ||  fieldName == "numComponents") {
+                    Array.forEach(this._parentNodes, function (node) {
+                        node.fieldChanged("attrib_"+that._vf.name);
+                    });
+                }
+            }
         }
     )
 );

--- a/src/nodes/Shaders/Varying.js
+++ b/src/nodes/Shaders/Varying.js
@@ -1,0 +1,30 @@
+/** @namespace x3dom.nodeTypes */
+/*
+ * X3DOM JavaScript Library
+ * http://www.x3dom.org
+ *
+ * (C)2009 Fraunhofer IGD, Darmstadt, Germany
+ * Dual licensed under the MIT and GPL
+ */
+
+/* ### Uniform ### */
+x3dom.registerNodeType(
+    "Varying",
+    "Shaders",
+    defineClass(x3dom.nodeTypes.Field,
+        
+        /**
+         * Constructor for Varying
+         * @constructs x3dom.nodeTypes.Varying
+         * @x3d x.x
+         * @component Shaders
+         * @extends x3dom.nodeTypes.Field
+         * @param {Object} [ctx=null] - context object, containing initial settings like namespace
+         * @classdesc Node representing a Varying.
+         */
+        function (ctx) {
+            x3dom.nodeTypes.Varying.superClass.call(this, ctx);
+        
+        }
+    )
+);

--- a/src/shader/ShaderDynamic.js
+++ b/src/shader/ShaderDynamic.js
@@ -206,11 +206,33 @@ x3dom.shader.DynamicShader.prototype.generateVertexShader = function(gl, propert
 		shader += "uniform float bgPrecisionTexMax;\n";
 	}
 
+    if(properties.CUSTOM_ATTR) {
+        var type;
+        for (var j = 0, n = properties.CUSTOM_ATTR.length; j < n ; j++) {
+            switch (properties.CUSTOM_ATTR[j].numComponents) {
+            case 2:
+                type = "vec2 ";
+                break;
+            case 3:
+                type = "vec3 ";
+                break;
+            case 4:
+                type = "vec4 ";
+                break;
+            default:
+                type = "float ";
+                break;
+            }
+            shader += "attribute "+type+properties.CUSTOM_ATTR[j].name+";\n";
+        }
+    }
+    shader += properties.CUSTOM_ATTRIBUTES.vertexShaderPartInit+"\n";
       
 	/*******************************************************************************
 	* Generate main function
 	********************************************************************************/
 	shader += "void main(void) {\n";
+	shader += properties.CUSTOM_ATTRIBUTES.vertexShaderPartMain+"\n";
   
 	/*******************************************************************************
 	* Start of special Geometry switch
@@ -618,12 +640,14 @@ x3dom.shader.DynamicShader.prototype.generateFragmentShader = function(gl, prope
     // Declare gamma correction for color computation (see property "GAMMACORRECTION")
     shader += x3dom.shader.gammaCorrectionDecl(properties);
  
+    shader +=  properties.CUSTOM_ATTRIBUTES.fragmentShaderPartInit+"\n";
  
 	/*******************************************************************************
 	* Generate main function
 	********************************************************************************/
 	shader += "void main(void) {\n";
 
+	shader +=  properties.CUSTOM_ATTRIBUTES.fragmentShaderPartMain+"\n";
 
     if(properties.CLIPPLANES)
     {

--- a/src/shader/ShaderDynamic.js
+++ b/src/shader/ShaderDynamic.js
@@ -232,7 +232,6 @@ x3dom.shader.DynamicShader.prototype.generateVertexShader = function(gl, propert
 	* Generate main function
 	********************************************************************************/
 	shader += "void main(void) {\n";
-	shader += properties.CUSTOM_ATTRIBUTES.vertexShaderPartMain+"\n";
   
 	/*******************************************************************************
 	* Start of special Geometry switch
@@ -483,6 +482,7 @@ x3dom.shader.DynamicShader.prototype.generateVertexShader = function(gl, propert
         shader += "gl_PointSize = 2.0;\n";
     }
   
+	shader +=  properties.CUSTOM_ATTRIBUTES.vertexShaderPartMain+"\n";
 	//END OF SHADER
 	shader += "}\n";
 	

--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -1073,12 +1073,27 @@ x3dom.Utils.generateProperties = function (viewarea, shape)
             "vertexShaderPartInit":"",   "vertexShaderPartMain":"",
             "fragmentShaderPartInit":"", "fragmentShaderPartMain":""
         };
+        var j, uniform, varying;
         for (i = 0, n = geometry._cf.customAttributes.nodes.length; i < n ; i++) {
-            var shaders = geometry._cf.customAttributes.nodes[i]._vf;
-            property.CUSTOM_ATTRIBUTES.vertexShaderPartInit += shaders.vertexShaderPartInit;
-            property.CUSTOM_ATTRIBUTES.vertexShaderPartMain += shaders.vertexShaderPartMain;
-            property.CUSTOM_ATTRIBUTES.fragmentShaderPartInit += shaders.fragmentShaderPartInit;
-            property.CUSTOM_ATTRIBUTES.fragmentShaderPartMain += shaders.fragmentShaderPartMain;
+            var shaders = geometry._cf.customAttributes.nodes[i];
+            for (j = 0; j< shaders._cf.uniforms.nodes.length; j++){
+                uniform = shaders._cf.uniforms.nodes[j]._vf;
+                property.CUSTOM_ATTRIBUTES.vertexShaderPartInit +=
+                    "uniform "+uniform.type+" "+uniform.name+"; ";
+                property.CUSTOM_ATTRIBUTES.fragmentShaderPartInit +=
+                    "uniform "+uniform.type+" "+uniform.name+"; ";
+            }
+            for (j = 0; j< shaders._cf.varyings.nodes.length; j++){
+                varying = shaders._cf.varyings.nodes[j]._vf;
+                property.CUSTOM_ATTRIBUTES.vertexShaderPartInit +=
+                    "varying "+varying.type+" "+varying.name+"; ";
+                property.CUSTOM_ATTRIBUTES.fragmentShaderPartInit +=
+                    "varying "+varying.type+" "+varying.name+";";
+            }
+            property.CUSTOM_ATTRIBUTES.vertexShaderPartMain +=
+                shaders._vf.vertexShaderPartMain;
+            property.CUSTOM_ATTRIBUTES.fragmentShaderPartMain +=
+                shaders._vf.fragmentShaderPartMain;
         }
 
         //console.log(property);

--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -1063,6 +1063,24 @@ x3dom.Utils.generateProperties = function (viewarea, shape)
 
         property.GAMMACORRECTION  = environment._vf.gammaCorrectionDefault;
 
+        property.CUSTOM_ATTR = [];
+        for (var i = 0, n = geometry._cf.attrib.nodes.length; i < n ; i++) {
+            property.CUSTOM_ATTR.push({
+                "name": geometry._cf.attrib.nodes[i]._vf.name,
+                "numComponents":geometry._cf.attrib.nodes[i]._vf.numComponents});
+        }
+        property.CUSTOM_ATTRIBUTES = {
+            "vertexShaderPartInit":"",   "vertexShaderPartMain":"",
+            "fragmentShaderPartInit":"", "fragmentShaderPartMain":""
+        };
+        for (i = 0, n = geometry._cf.customAttributes.nodes.length; i < n ; i++) {
+            var shaders = geometry._cf.customAttributes.nodes[i]._vf;
+            property.CUSTOM_ATTRIBUTES.vertexShaderPartInit += shaders.vertexShaderPartInit;
+            property.CUSTOM_ATTRIBUTES.vertexShaderPartMain += shaders.vertexShaderPartMain;
+            property.CUSTOM_ATTRIBUTES.fragmentShaderPartInit += shaders.fragmentShaderPartInit;
+            property.CUSTOM_ATTRIBUTES.fragmentShaderPartMain += shaders.fragmentShaderPartMain;
+        }
+
         //console.log(property);
 	}
 

--- a/tools/packages.json
+++ b/tools/packages.json
@@ -229,6 +229,7 @@
                 ]},
                 {"name": "Shaders", "filePrefix": "nodes/Shaders/", "files":[
                     {"file": "Uniform.js"},
+                    {"file": "Varying.js"},
                     {"file": "SurfaceShaderTexture.js"},
                     {"file": "X3DShaderNode.js"},
                     {"file": "CommonSurfaceShader.js"},

--- a/tools/packages.json
+++ b/tools/packages.json
@@ -113,6 +113,7 @@
                     {"file": "Color.js"},
                     {"file": "ColorRGBA.js"},
                     {"file": "ParticleSet.js"},
+                    {"file": "CustomAttributeNode.js"},
                     {"file": "ClipPlane.js"}
                 ]},
                 {"name": "Shape", "filePrefix": "nodes/Shape/", "files":[


### PR DESCRIPTION
During my internship, I worked on the creation of x3dom-based tools
for mesh data visualization and analysis. I wanted to create new DOM
nodes that integrate nicely in a standard x3dom tree, namely
iso-color, threshold, clip-plane.

I had two goals in mind:

1. create an x3dom plugin API that allows one to create new DOM nodes
   which extend x3dom functionality;
2. keep a simple x3dom-like interface for the final users.

**In this branch I created a new node : CustomAttributeNode. This node 
serve as entry point in x3dom to use the API.**

For a detailed technical explanation of the API take a look at [the GitHub 
repository](https://github.com/YuanxiangFranck/x3dom-plugins-API) of 
my demonstration.


**Example of the API:**

Following example illustrates the usage of such plugins. The relevant
markup looks like:

```html
<TriangleSet>
  <Coordinate point="..."> </Coordinate>
  <Normal vector="..."> </Normal>
  <Threshold
     upperBound="1" lowerBound="0" dataName="triSetData" > </Threshold>
  <IsoColor
     max="1" min="0" dataName="triSetData" > </IsoColor>
  <FloatVertexAttribute
     name="triSetData" numComponents="1" value="..."> </FloatVertexAttribute>
  <FloatVertexAttribute
     name="other_set_of_data" numComponents="1" value="..."> </FloatVertexAttribute>
  ...
</TriangleSet>
```

The **Threshold** and **IsoColor** nodes work like any x3dom node:
they react to any attribute change using DOM's node **setAttribute**
method. This makes it easy to use HTML widgets like sliders / buttons
to drive the plugin's parameters.

Example and live demonstration on:
[**http://yuanxiangfranck.github.io/x3dom-plugins-API/**](http://yuanxiangfranck.github.io/x3dom-plugins-API/)