### PR TITLE
fix text for VR (rendered texture)

### DIFF
--- a/src/nodes/Text/Text.js
+++ b/src/nodes/Text/Text.js
@@ -73,7 +73,7 @@ x3dom.registerNodeType(
              */
             this.addField_SFNode ('fontStyle', x3dom.nodeTypes.X3DFontStyleNode);
 
-            this._mesh._positions[0] = [];
+            this._mesh._positions[0] = [0,0,0, 1,0,0, 1,1,0, 0,1,0];
             this._mesh._normals[0]   = [0,0,1, 0,0,1, 0,0,1, 0,0,1];
             this._mesh._texCoords[0] = [0,0, 1,0, 1,1, 0,1];
             this._mesh._colors[0] 	 = [];


### PR DESCRIPTION
An empty array for mesh vertex positions leads to a 0 volume for getVolume(). This in turn leads to small feature culling in renderedTexture (and when otherwise requested as it seems to be switched on now by default). This is why text does not display in VR.

The fix simply provides some non-null geometry which leads to initial non-null volume. SInce then text is not culled, the mesh positions get updated to the real geometry (in Texture.js) and getVolume() will get the real volume.