### PR TITLE
Apply devicePixelRatio to canvas coordinates on scaled displays

### DIFF
--- a/src/X3DCanvas.js
+++ b/src/X3DCanvas.js
@@ -1317,8 +1317,10 @@ x3dom.X3DCanvas.prototype.mousePosition = function(evt)
         var paddingTop = parseFloat(compStyle.getPropertyValue('padding-top'));
         var borderTopWidth = parseFloat(compStyle.getPropertyValue('border-top-width'));
 
-        x = Math.round(evt.pageX - (box.left + paddingLeft + borderLeftWidth + scrollLeft));
-        y = Math.round(evt.pageY - (box.top + paddingTop + borderTopWidth + scrollTop));
+        // account for scaled canvas element
+        var devicePixelRatio = window.devicePixelRatio || 1.0;
+        x = Math.round(devicePixelRatio * (evt.pageX - (box.left + paddingLeft + borderLeftWidth + scrollLeft)));
+        y = Math.round(devicePixelRatio * (evt.pageY - (box.top + paddingTop + borderTopWidth + scrollTop)));
     }
     else {
         x3dom.debug.logError('NO getBoundingClientRect');


### PR DESCRIPTION
Picking was broken on scaled displays, e.g. Windows scaled to 125% for high DPI display devices. This can easily be seen in the picking demo, but applied equally to any combined use of runtime.mousePosition, runtime.pickRect, or accessing Event.hitPnt.  The coordinates returned for a MouseEvent did not account for the previous use of scaling on the 3d canvas element, resulting in a visible offset between the physical mouse position and the logical position computed by mousePosition.  Scaling the result of this function corrects the issue.