### PR TITLE
Added compatibility with python 3 and 2 for manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 from __future__ import with_statement
 # -------------------------------------------------------------------
 # NOTE:
@@ -68,9 +69,9 @@ from __future__ import with_statement
 try:
     import argparse
 except:
-    print "\nYou need to install argparse. Please run the following command:"
-    print "on your command line and try again:\n"
-    print "    easy_install argparse\n"
+    print("\nYou need to install argparse. Please run the following command:")
+    print("on your command line and try again:\n")
+    print("    easy_install argparse\n")
     exit()
 
 import os
@@ -143,7 +144,7 @@ def build(mode='production'):
             """
 #            shutil.copy(src, nodes_dest)
         except:
-            print "  Error copying file to %s" % component
+            print("  Error copying file to %s" % component)
     # done with components
     
     # ~~ copy other files ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -177,8 +178,12 @@ def release(version='snapshot'):
     _zipdir(DIST_ROOT, 'dist/x3dom-%s.zip' % version)
 
 def runserver():
-    import SimpleHTTPServer
-    import SocketServer
+    try:
+        import http.server as SimpleHTTPServer
+        import socketserver as SocketServer
+    except ImportError:
+        import SimpleHTTPServer
+        import SocketServer
 
     print("Starting development server...")
     print("Open your browser and visit http://localhost:8080/")

--- a/tools/jspacker.py
+++ b/tools/jspacker.py
@@ -6,7 +6,7 @@
 ##  Web: http://creativecommons.org/licenses/LGPL/2.1/
 ##
 ##  Ported to Python by Florian Schulze
-
+from __future__ import print_function
 import os, re
 
 # a multi-pattern parser
@@ -103,7 +103,7 @@ class ParseMaster:
         for pattern in self._patterns:
             if match.group(i) is not None:
                 replacement = pattern.replacement
-                if callable(replacement):
+                if isinstance(replacement, collections.Callable):
                     return replacement(match, i)
                 elif isinstance(replacement, (int, long)):
                     return match.group(replacement+i)
@@ -557,14 +557,14 @@ function _bar(_ocalvar) {
             _expected = open(expected).read()
         else:
             _expected = expected
-        print script[:20], encoding, fastDecode, specialChars, expected[:20]
-        print "="*40
+        print(script[:20], encoding, fastDecode, specialChars, expected[:20])
+        print("="*40)
         result = p.pack(_script, encoding, fastDecode, specialChars)
-        print len(result), len(_script)
+        print(len(result), len(_script))
         if (result != _expected):
-            print "ERROR!!!!!!!!!!!!!!!!"
-            print _expected
-            print result
+            print("ERROR!!!!!!!!!!!!!!!!")
+            print(expected)
+            print(result)
             #print list(difflib.unified_diff(result, _expected))
 
 if __name__=='__main__':

--- a/tools/packages.py
+++ b/tools/packages.py
@@ -1,6 +1,8 @@
 
 def prefix_path(lst, path):
-    return [path + '/' + entry for entry in lst]
+    return [path + '/' + x for entry in lst for y in entry if type(y) == list for x in y]
+    #return [path + '/' + entry for entry in lst]
+
 
 
 def getPathTuples(data):

--- a/tools/x3dom_packer.py
+++ b/tools/x3dom_packer.py
@@ -1,16 +1,24 @@
 #!/usr/bin/python
+# coding=utf-8
 
-from StringIO import StringIO
+from __future__ import print_function
+
+import sys
+if (sys.version_info > (3, 0)):
+    from io import StringIO
+else:
+    try:
+        from io import BytesIO as StringIO
+    except ImportError:
+        import StringIO
 from optparse import OptionParser
 import os
 from os.path import isfile, join
 import re
 from subprocess import Popen, PIPE
-import sys
 
 import jsmin
-from jspacker import JavaScriptPacker
-
+from .jspacker import JavaScriptPacker
 
 VERSION_TEMPLATE = """
 x3dom.versionInfo = {
@@ -38,7 +46,7 @@ class packer(object):
     
     version_out = "version.js"
     
-    print "Generating version.js"
+    print("Generating version.js")
     
     # Read the base-version from the VERSION file
     if os.path.isfile(version_in):
@@ -50,7 +58,7 @@ class packer(object):
       version_file.close()
       
     else:
-      print "FATAL: Cannot find VERSION file: " + version_in
+      print("FATAL: Cannot find VERSION file: " + version_in)
       sys.exit(0)
     
     # Extract the git revision 
@@ -60,14 +68,14 @@ class packer(object):
     except:
       git_revision = 0
       git_date = 0
-      print "  WARNING:  Cannot find git executable"
+      print("  WARNING:  Cannot find git executable")
       
-    print "  Input    ", os.path.abspath(version_in)
-    print "  Output   ", os.path.abspath(version_out)
-    print "  Version  ", version
-    print "  Revision ", git_revision
-    print "  Date     ", git_date
-    print ""
+    print("  Input    ", os.path.abspath(version_in))
+    print("  Output   ", os.path.abspath(version_out))
+    print("  Version  ", version)
+    print("  Revision ", git_revision)
+    print("  Date     ", git_date)
+    print("")
     
     # Write the version and revision to file
     version_js_file = open(version_out, "w")
@@ -94,12 +102,12 @@ class packer(object):
       """
       # print "File:", filename
       try:
-        print "  " + os.path.abspath(filename)
+        print("  " + os.path.abspath(filename))
         f = open(filename, 'r')
         concatenated_file += f.read()
         f.close()
       except:
-        print "Could not open input file '%s'. Skipping" % filename    
+        print("Could not open input file '%s'. Skipping" % filename)
       concatenated_file += "\n"
       return concatenated_file
   
@@ -132,8 +140,8 @@ class packer(object):
     @type src_prefix_path: String
     """
     
-    print "output file:", output_file
-    print "input_files:", input_files
+    print("output file:", output_file)
+    print("input_files:", input_files)
     
     version_out = ""
     
@@ -144,12 +152,12 @@ class packer(object):
         elif os.path.isfile("src/VERSION"):
             version_file_name = "src/VERSION"
         else:
-            print "FATAL: Cannot find any VERSION file"
+            print("FATAL: Cannot find any VERSION file")
             sys.exit(0)
     
         # parse file & generate version.js
-        version_out = self.generate_version_file(version_file_name);
-    
+        version_out = self.generate_version_file(version_file_name)
+
         # Add the version.js to the list of input files
         input_files.append((version_out, [version_out]))
 
@@ -158,7 +166,7 @@ class packer(object):
     out_len = 0
     
     # Merging files
-    print "Packing Files"
+    print("Packing Files")
     for (_, files) in input_files:
         for f in files:
             if f == version_out:
@@ -180,27 +188,27 @@ class packer(object):
                       concatenated_file = self._mergeFile(concatenated_file, join(filename,node_file))
             """
     
-    print ""
+    print("")
     
     outpath = os.path.dirname(os.path.abspath(output_file))
     
     if not os.access(outpath, os.F_OK):
-      print "Create Dir ", outpath
+      print("Create Dir ", outpath)
       os.mkdir(outpath)
     
     # Packaging
-    print "Packaging"
-    print self.VERSION_STRING
-    print "  Algo    " + packaging_module
-    print "  Output  " + os.path.abspath(output_file)
+    print("Packaging")
+    print(self.VERSION_STRING)
+    print("  Algo    " + packaging_module)
+    print("  Output  " + os.path.abspath(output_file))
     
     # JSMIN
     if packaging_module == "jsmin":
       # Minifiy the concatenated files
-      out_stream = StringIO()  
+      out_stream = StringIO()
       jsm = jsmin.JavascriptMinify()
-      jsm.minify(StringIO(concatenated_file), out_stream)   
-                      
+      jsm.minify(StringIO(concatenated_file), out_stream)
+
       out_len = len(out_stream.getvalue())
       
       # Write the minified output file
@@ -248,26 +256,26 @@ class packer(object):
     # Output some stats
     in_len = len(concatenated_file)    
     ratio = float(out_len) / float(in_len);
-    print "  Packed  %s -> %s" % (in_len, out_len)
-    print "  Ratio   %s" % (ratio)
+    print("  Packed  %s -> %s" % (in_len, out_len))
+    print("  Ratio   %s" % ratio)
 
 if __name__ == '__main__':
     parser = OptionParser(usage)
-    
+
     parser.add_option("-a", "--algo", type="string", dest="algo", help='The algorithm to use. [jsmin, jspacker, closure, none]', default="jsmin")
     parser.add_option("-o", "--outfile", type="string", dest="outfile", help='The name of the output file.')
-    
+
     (options, input_files) = parser.parse_args()
-    
+
     if len(input_files) == 0:
-      print parser.print_help()
-      print "- No input files specified. Exiting -"
+      print(parser.print_help())
+      print("- No input files specified. Exiting -")
       sys.exit(0)
-    
+
     if not options.outfile:
-      print parser.print_help()
-      print "- Please specify an output file using the -o options. Exiting. -"
+      print(parser.print_help())
+      print("- Please specify an output file using the -o options. Exiting. -")
       sys.exit(0)
-    
+
     x3dom_packer = packer()
     x3dom_packer.build(input_files, options.outfile, options.algo)


### PR DESCRIPTION
In reference to issue # #661 This should help with the support for both python 2.7 and 3.5 users to use the `manage.py` script.
Tested the following commands:

```
python manage.py --runserver
python manage.py --build
python manage.py --stats
```
