### PR TITLE
Fix reset of request queues in RequestManager

### DIFF
--- a/src/util/RequestManager.js
+++ b/src/util/RequestManager.js
@@ -152,7 +152,8 @@ x3dom.RequestManager.abortAllRequests = function()
         this.activeRequests[ i ].abort();
     }
 
-    this.requests = this.activeRequests = [];
+    this.requests = [];
+    this.activeRequests = [];
 };
 
 /**


### PR DESCRIPTION
The `abortAllRequests`-function in RequestManager uses one line variable assignment which leads to `this.requests` and `this.activeRequests` referencing the same object after _reset_. Hence in next run requests _active_ as soon as stored on `this.requests`.