### PR TITLE
Reset RequestManger counters when all requests are aborted

### DIFF
--- a/src/util/RequestManager.js
+++ b/src/util/RequestManager.js
@@ -174,6 +174,9 @@ x3dom.RequestManager.abortAllRequests = function()
 
     this.requests = [];
     this.activeRequests = [];
+    this.failedRequests = 0;
+    this.loadedRequests = 0;
+    this.totalRequests = 0;
 
     this.onAbortAllRequests( this._getCounters() );
 }


### PR DESCRIPTION
I have noticed that when one aborts all requests via Request Managers the counters are not reset. When one starts new requests afterwards, the counters show wrong results e.g. total considers the also aborted requests so loaded count can never again equal with total requests. 