### PR TITLE
Fix default UV mapping

### DIFF
--- a/src/Mesh.js
+++ b/src/Mesh.js
@@ -409,8 +409,7 @@ x3dom.Mesh.prototype.calcTexCoords = function(mode)
         for (var k=0, l=0, m=this._positions[0].length; k<m; k+=3)
         {
             this._texCoords[0][l++] = (this._positions[0][k+S] - sMin) / sDenom;
-            this._texCoords[0][l++] = (this._positions[0][k+T] - tMin) / tDenom;
+            this._texCoords[0][l++] = (this._positions[0][k+T] - tMin) / sDenom;
         }
     }
 };
-


### PR DESCRIPTION
Fix https://github.com/x3dom/x3dom/issues/411

## Summary

The X3Dom default UV mapping is not respecting well the X3D reference:

http://www.web3d.org/documents/specifications/19775-1/V3.3/Part01/components/geometry3D.html#f-IndexedFaceSettextureDefaultMapping

The issue is that the second UV coordinate (aka `T`) should be truncated by the first coordinate (aka `S`).

## Test X3D file

[default-mapping.zip](https://github.com/x3dom/x3dom/files/1124198/default-mapping.zip)

## Results

Note: I tested on my implementation and on Blender giving the same results.

| Original | Patched | Reference (my implementation) |
| --- | --- | --- |
| ![capture d ecran 2017-07-05 a 11 40 48](https://user-images.githubusercontent.com/866788/27858789-d824bc26-6176-11e7-95e5-fd94d107c9f7.png) | ![capture d ecran 2017-07-05 a 11 39 26](https://user-images.githubusercontent.com/866788/27858790-d89e03e2-6176-11e7-9965-9432f99e11da.png) | ![capture d ecran 2017-07-05 a 11 39 04](https://user-images.githubusercontent.com/866788/27858788-d7be30be-6176-11e7-9578-0e6b5833d3e5.png) |
