### PR TITLE
CoordinateDouble node implementation

### DIFF
--- a/src/nodes/Rendering/CoordinateDouble.js
+++ b/src/nodes/Rendering/CoordinateDouble.js
@@ -1,0 +1,47 @@
+/** @namespace x3dom.nodeTypes */
+/*
+ * X3DOM JavaScript Library
+ * http://www.x3dom.org
+ *
+ * (C)2017 A. Plesch, Fraunhofer IGD, Darmstadt, Germany
+ * Dual licensed under the MIT and GPL
+ */
+
+/* ### Coordinate ### */
+x3dom.registerNodeType(
+    "CoordinateDouble",
+    "Nurbs",
+    defineClass(x3dom.nodeTypes.X3DCoordinateNode,
+        
+        /**
+         * Constructor for CoordinateDouble
+         * @constructs x3dom.nodeTypes.CoordinateDouble
+         * @x3d 3.3
+         * @component Nurbs
+         * @status full
+         * @extends x3dom.nodeTypes.X3DCoordinateNode
+         * @param {Object} [ctx=null] - context object, containing initial settings like namespace
+         * @classdesc Coordinate builds geometry using a set of double precision 3D coordinates.
+         * Coordinate is used by IndexedFaceSet, IndexedLineSet, LineSet and PointSet.
+         */
+        function (ctx) {
+            x3dom.nodeTypes.Coordinate.superClass.call(this, ctx);
+
+            /**
+             * Contains the 3D coordinates
+             * @var {x3dom.fields.MFVec3d} point
+             * @memberof x3dom.nodeTypes.Coordinate
+             * @initvalue []
+             * @field x3d
+             * @instance
+             */
+            this.addField_MFVec3d(ctx, 'point', []);
+        
+        },
+        {
+            getPoints: function() {
+                return this._vf.point;
+            }
+        }
+    )
+);

--- a/src/nodes/Rendering/CoordinateDouble.js
+++ b/src/nodes/Rendering/CoordinateDouble.js
@@ -22,10 +22,10 @@ x3dom.registerNodeType(
          * @extends x3dom.nodeTypes.X3DCoordinateNode
          * @param {Object} [ctx=null] - context object, containing initial settings like namespace
          * @classdesc Coordinate builds geometry using a set of double precision 3D coordinates.
-         * Coordinate is used by IndexedFaceSet, IndexedLineSet, LineSet and PointSet.
+         * X3DCoordinateNode is used by IndexedFaceSet, IndexedLineSet, LineSet and PointSet.
          */
         function (ctx) {
-            x3dom.nodeTypes.Coordinate.superClass.call(this, ctx);
+            x3dom.nodeTypes.CoordinateDouble.superClass.call(this, ctx);
 
             /**
              * Contains the 3D coordinates

--- a/tools/packages.json
+++ b/tools/packages.json
@@ -19,8 +19,8 @@
                 {"path": "util/StateManager.js"},
                 {"path": "util/BinaryContainerSetup.js"},
                 {"path": "util/DrawableCollection.js"},
-				{"path": "util/Moveable.js"},
-				{"path": "util/Zlib.js"},
+                {"path": "util/Moveable.js"},
+                {"path": "util/Zlib.js"},
                 {"path": "util/glTF/glTFLoader.js"},
                 {"path": "util/glTF/glTFContainer.js"},
                 {"path": "X3DCanvas.js"},
@@ -42,8 +42,8 @@
                 {"path": "shader/ShaderParts.js"},
                 {"path": "shader/ShaderDynamic.js"},
                 {"path": "shader/ShaderDynamicMobile.js"},
-		        {"path": "shader/ShaderDynamicPicking.js"},
-				{"path": "shader/ShaderDynamicShadow.js"},
+                {"path": "shader/ShaderDynamicPicking.js"},
+                {"path": "shader/ShaderDynamicShadow.js"},
                 {"path": "shader/ShaderComposed.js"},
                 {"path": "shader/ShaderNormal.js"},
                 {"path": "shader/ShaderFrontgroundTexture.js"},
@@ -54,8 +54,8 @@
                 {"path": "shader/ShaderTextureRefinement.js"},
                 {"path": "shader/ShaderBlur.js"},
                 {"path": "shader/ShaderKHRMaterialCommons.js"},
-		{"path": "shader/ShaderSSAO.js", "type": "file"},
-		{"path": "shader/ShaderSSAOBlur.js", "type": "file"}
+                {"path": "shader/ShaderSSAO.js", "type": "file"},
+                {"path": "shader/ShaderSSAOBlur.js", "type": "file"}
             ]},
 
         {"group": "GFX",
@@ -63,7 +63,6 @@
 		        {"path": "SSAO.js", "type": "file"},
                 {"path": "gfx_webgl.js"}
             ]},
-
 
         {"group": "COMPONENTS",
             "data": [
@@ -112,6 +111,7 @@
                     {"file": "X3DGeometricPropertyNode.js"},
                     {"file": "X3DCoordinateNode.js"},
                     {"file": "Coordinate.js"},
+                    {"file": "CoordinateDouble.js"},
                     {"file": "Normal.js"},
                     {"file": "X3DColorNode.js"},
                     {"file": "Color.js"},
@@ -277,6 +277,17 @@
                     {"file": "PlaneSensor.js"},
                     {"file": "SphereSensor.js"},
                     {"file": "CylinderSensor.js"}
+                ]},
+                {"name": "EventUtilities", "filePrefix": "nodes/EventUtilities/", "files":[
+                    {"file": "X3DSequencerNode.js"},
+                    {"file": "X3DTriggerNode.js"},
+                    {"file": "BooleanFilter.js"},
+                    {"file": "BooleanSequencer.js"},
+                    {"file": "BooleanToggle.js"},
+                    {"file": "BooleanTrigger.js"},
+                    {"file": "IntegerSequencer.js"},
+                    {"file": "IntegerTrigger.js"},
+                    {"file": "TimeTrigger.js"}
                 ]}
             ]},
 
@@ -361,6 +372,7 @@
                 ]}              
             ]
 		},
+        
 		{"group": "PHYSIC_EXTENSIONS",
             "data": [
                 {"name": "RigidBodyPhysics", "filePrefix": "nodes/RigidBodyPhysics/", "files":[                    
@@ -381,6 +393,7 @@
                 ]}
 			]
 		},
+        
         {"group": "COMPRESSED_EXT_LIBS",
                 "data": [
                     {"name": "Ammo", "filePrefix": "../lib/", "files":[                    


### PR DESCRIPTION
This node may help with scene compatibility across x3d browser. Example use: https://jsfiddle.net/fzzgso28/1/
Also see http://web3d.org/pipermail/x3d-public_web3d.org/2017-September/007421.html and thread for some discussion.
The CoordinateDouble.js file was placed next to Coordinate.js file in the Rendering folder although it belongs with Nurbs component. Feel free to move to another location.