### PR TITLE
Add property to NavigationInfo for natural Scrolling. Fixes #486

### DIFF
--- a/src/X3DCanvas.js
+++ b/src/X3DCanvas.js
@@ -293,8 +293,12 @@ x3dom.X3DCanvas.prototype.bindEventListeners = function() {
             this.focus();
 
             var originalY = this.parent.mousePosition(evt).y;
-
-            this.mouse_drag_y += 2 * evt.detail;
+            if(this.parent.doc._scene.getNavigationInfo()._vf.naturalScroll == true){
+                this.mouse_drag_y -= 2 * evt.detail;
+            }
+            else{
+                this.mouse_drag_y += 2 * evt.detail;
+            }
 
             this.parent.doc.onWheel(that.gl, this.mouse_drag_x, this.mouse_drag_y, originalY);
             this.parent.doc.needRender = true;
@@ -316,8 +320,13 @@ x3dom.X3DCanvas.prototype.bindEventListeners = function() {
             this.focus();
 
             var originalY = this.parent.mousePosition(evt).y;
-
-            this.mouse_drag_y -= 0.1 * evt.wheelDelta;
+            
+            if(this.parent.doc._scene.getNavigationInfo()._vf.naturalScroll == true){
+                this.mouse_drag_y += 0.1 * evt.wheelDelta;
+            }
+            else{
+                this.mouse_drag_y -= 0.1 * evt.wheelDelta;
+            }
 
             this.parent.doc.onWheel(that.gl, this.mouse_drag_x, this.mouse_drag_y, originalY);
             this.parent.doc.needRender = true;

--- a/src/X3DCanvas.js
+++ b/src/X3DCanvas.js
@@ -293,7 +293,7 @@ x3dom.X3DCanvas.prototype.bindEventListeners = function() {
             this.focus();
 
             var originalY = this.parent.mousePosition(evt).y;
-            if(this.parent.doc._scene.getNavigationInfo()._vf.naturalScroll == true){
+            if(this.parent.doc._scene.getNavigationInfo()._vf.reverseScroll == true){
                 this.mouse_drag_y -= 2 * evt.detail;
             }
             else{
@@ -321,7 +321,7 @@ x3dom.X3DCanvas.prototype.bindEventListeners = function() {
 
             var originalY = this.parent.mousePosition(evt).y;
             
-            if(this.parent.doc._scene.getNavigationInfo()._vf.naturalScroll == true){
+            if(this.parent.doc._scene.getNavigationInfo()._vf.reverseScroll == true){
                 this.mouse_drag_y += 0.1 * evt.wheelDelta;
             }
             else{

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -44,7 +44,7 @@ x3dom.registerNodeType(
              * @var {x3dom.fields.SFBool} naturalScroll
              * @memberof x3dom.nodeTypes.NavigationInfo
              * @initvalue false
-             * @field x3d
+             * @field x3dom
              * @instance
              */
             this.addField_SFBool(ctx, 'naturalScroll', false);

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -40,6 +40,16 @@ x3dom.registerNodeType(
             this.addField_SFBool(ctx, 'headlight', true);
 
             /**
+             * Enable/disable natural mousewheel scrolling.
+             * @var {x3dom.fields.SFBool} naturalScroll
+             * @memberof x3dom.nodeTypes.NavigationInfo
+             * @initvalue false
+             * @field x3d
+             * @instance
+             */
+            this.addField_SFBool(ctx, 'naturalScroll', false);
+
+            /**
              * defines the navigation type
              * @var {x3dom.fields.MFString} type
              * @range {"ANY","WALK","EXAMINE","FLY","LOOKAT","NONE","EXPLORE",...}

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -47,7 +47,7 @@ x3dom.registerNodeType(
              * @field x3dom
              * @instance
              */
-            this.addField_SFBool(ctx, 'naturalScroll', false);
+            this.addField_SFBool(ctx, 'reverseScroll', false);
 
             /**
              * defines the navigation type

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -40,8 +40,8 @@ x3dom.registerNodeType(
             this.addField_SFBool(ctx, 'headlight', true);
 
             /**
-             * Enable/disable natural mousewheel scrolling.
-             * @var {x3dom.fields.SFBool} naturalScroll
+             * Enable/disable reversed mousewheel scrolling to zoom.
+             * @var {x3dom.fields.SFBool} reverseScroll
              * @memberof x3dom.nodeTypes.NavigationInfo
              * @initvalue false
              * @field x3dom


### PR DESCRIPTION
This PR adds a property called `naturalScoll` to the NavigationInfo-Node, which inverts the scroll-events and thus fixes #486.