### PR TITLE
Let <code> elements wrap white space

### DIFF
--- a/doc/x3doc/base/static/styles/x3dom-docs-new.css
+++ b/doc/x3doc/base/static/styles/x3dom-docs-new.css
@@ -697,7 +697,7 @@ code {
     font-size: 90%;
     color: #c7254e;
     background-color: #f9f2f4;
-    white-space: nowrap;
+    white-space: normal;
     border-radius: 0;
 }
 kbd {


### PR DESCRIPTION
Earlier today I tried reading your documentation page for IndexedFaceSet on my iPad. The entire page was zoomed out to accommodate the &lt;code&gt; element near the top, making it impossible to read without zooming in. Even for browsers that do not zoom out for extremely long lines, most of the text will be outside of the visible window and not easily accessible.

This small change keeps the HTML encoding of the node and all of its defaults in a compact wrapped area where everything is easily seen, making the documentation more useful.