### PR TITLE
Update X3DVolumeDataNode.js

### DIFF
--- a/src/nodes/VolumeRendering/X3DVolumeDataNode.js
+++ b/src/nodes/VolumeRendering/X3DVolumeDataNode.js
@@ -166,9 +166,9 @@ x3dom.registerNodeType(
                 "  s1 = floor(volpos.z*nS);\n"+
                 "  s2 = s1+1.0;\n"+
                 "  dx1 = fract(s1/nX);\n"+
-                "  dy1 = floor(s1/nY)/nY;\n"+
+                "  dy1 = floor(s1/nX)/nY;\n"+
                 "  dx2 = fract(s2/nX);\n"+
-                "  dy2 = floor(s2/nY)/nY;\n"+
+                "  dy2 = floor(s2/nX)/nY;\n"+
                 "  texpos1.x = dx1+(volpos.x/nX);\n"+
                 "  texpos1.y = dy1+(volpos.y/nY);\n"+
                 "  texpos2.x = dx2+(volpos.x/nX);\n"+


### PR DESCRIPTION
In the function texture3DFunctionShaderText, the lines dy1 = floor(s1/nX)/nY; and dy2 = floor(s2/nX)/nY; are wrong, one must divided by nX instead of nY to get the correct texture position. Apparently this has been tested only on square texture-grids where nX equals nY.
This bug affects most volume rendering nodes!