### PR TITLE
fix parentRemoved function

### DIFF
--- a/src/nodes/Texturing/X3DTextureNode.js
+++ b/src/nodes/Texturing/X3DTextureNode.js
@@ -188,7 +188,9 @@ x3dom.registerNodeType(
                     else {
                         // Texture maybe in MultiTexture or CommonSurfaceShader
                         Array.forEach(shape._parentNodes, function (realShape) {
-                            realShape._dirty.texture = true;
+                            if (x3dom.isa(realShape, x3dom.nodeTypes.Shape)) {
+                                realShape._dirty.texture=true;
+                            }
                         });
                     }
                 });

--- a/src/nodes/Texturing/X3DTextureNode.js
+++ b/src/nodes/Texturing/X3DTextureNode.js
@@ -181,16 +181,14 @@ x3dom.registerNodeType(
             parentRemoved: function(parent)
             {
                 Array.forEach(parent._parentNodes, function (shape) {
-                    // THINKABOUTME: this is a bit ugly, cleanup more generically
-                    if (x3dom.isa(shape, x3dom.nodeTypes.Shape)) {
+                    // THINKABOUTME: cleanup more generically, X3DShapeNode allows VolumeData
+                    if (x3dom.isa(shape, x3dom.nodeTypes.X3DShapeNode)) {
                         shape._dirty.texture = true;
                     }
                     else {
                         // Texture maybe in MultiTexture or CommonSurfaceShader
                         Array.forEach(shape._parentNodes, function (realShape) {
-                            if (x3dom.isa(realShape, x3dom.nodeTypes.Shape)) {
-                                realShape._dirty.texture=true;
-                            }
+                            realShape._dirty.texture=true;
                         });
                     }
                 });

--- a/src/nodes/Texturing/X3DTextureNode.js
+++ b/src/nodes/Texturing/X3DTextureNode.js
@@ -188,7 +188,7 @@ x3dom.registerNodeType(
                     else {
                         // Texture maybe in MultiTexture or CommonSurfaceShader
                         Array.forEach(shape._parentNodes, function (realShape) {
-                            realShape._dirty.texture=true;
+                            realShape._dirty.texture = true;
                         });
                     }
                 });


### PR DESCRIPTION
When removing a VolumeData node from an X3D scene, the volume isn't removed and a console error is generated ':
Uncaught TypeError: Cannot set property 'texture' of undefined. See this example:
https://scalablebrainatlas.incf.org/x3bug/aorta_remove.xhtml
The added check in line 191 fixes the problem. I do not know what is really causing the error, whether more elegant solutions exist, and whether perhaps a similar fix is needed in line 175. The following page illustrates the desired behavior after the fix:
https://scalablebrainatlas.incf.org/x3bug/aorta_remove_fixed.xhtml