### PR TITLE
Avoid CORS error

### DIFF
--- a/doc/x3doc/base/tutorials/basics/imagesMovies/example.html
+++ b/doc/x3doc/base/tutorials/basics/imagesMovies/example.html
@@ -14,7 +14,7 @@
     <scene>
         <shape>
             <appearance>
-                <ImageTexture  url="http://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Peach_Rinkysplash.jpg/800px-Peach_Rinkysplash.jpg"></ImageTexture>
+                <ImageTexture  url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Peach_Rinkysplash.jpg/800px-Peach_Rinkysplash.jpg"></ImageTexture>
             </appearance>
             <box></box>
         </shape>


### PR DESCRIPTION
This image produces a CORS redirection error in Safari, but not in Chrome or Firefox. This simple edit solves that particular problem.