### PR TITLE
Update X3DCanvas.js to enable webgl2 context.

### DIFF
--- a/src/X3DCanvas.js
+++ b/src/X3DCanvas.js
@@ -101,9 +101,8 @@ x3dom.X3DCanvas = function(x3dElem, canvasIdx)
 	this.canvas.parent = this;
 	
 	this.gl = this._initContext( this.canvas, (this.backend.search("desktop") >= 0),
-											  (this.backend.search("mobile") >= 0),
-											  (this.backend.search("flashie") >= 0),
-											  (this.backend.search("webgl2") >= 0));
+		(this.backend.search("mobile") >= 0),
+		(this.backend.search("webgl2") >= 0));
 	this.backend = 'webgl';
 	
 	if (this.gl == null)


### PR DESCRIPTION
The call to this._initContext with five parameters does not match the function itself, which has four parameters. This is because in the call, the parameter for "flashie" is pased as the fourth parameter, while in the function itself this parameter has been removed. As a consequence, one could not use the tag <X3D backend="webgl2"> to invoke a webgl2 context, because the 'tryWebGL2' parameter is lost as the fifth parameter. The proposed change fixes this error.