### PR TITLE
Update gfx_webgl.js to enable webgl2 context

### DIFF
--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -42,7 +42,7 @@ x3dom.gfx_webgl = (function () {
         var validContextNames = ['webgl', 'experimental-webgl', 'moz-webgl', 'webkit-3d'];
 
         if (tryWebGL2) {
-            validContextNames = ['experimental-webgl2'].concat(validContextNames);
+            validContextNames = ['webgl2','experimental-webgl2'].concat(validContextNames);
         }
 
         var ctx = null;


### PR DESCRIPTION
In the old code, only 'experimental-webgl2' was tested as a context that invokes webgl2, and the name 'webgl2', which is used by most current browsers, is not tested. The proposed change fixes that error.