### PR TITLE
Remove reference to generation

### DIFF
--- a/doc/x3doc/base/author/index.html
+++ b/doc/x3doc/base/author/index.html
@@ -467,7 +467,7 @@
     </section>
 
     <footer>
-        This X3DOM documentation was generated with the help of <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.1.1</a> on Mon Jan 13 2014 10:50:16 GMT+0100 (MEZ)
+        <!-- This X3DOM documentation was generated with the help of <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.1.1</a> on Mon Jan 13 2014 10:50:16 GMT+0100 (MEZ) -->
     </footer>  
 </div>
 

--- a/doc/x3doc/base/developer/index.html
+++ b/doc/x3doc/base/developer/index.html
@@ -87,7 +87,7 @@
     </section>
 
     <footer>
-        This X3DOM documentation was generated with the help of <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.1.1</a> on Mon Jan 13 2014 10:50:16 GMT+0100 (MEZ)
+        <!-- This X3DOM documentation was generated with the help of <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.1.1</a> on Mon Jan 13 2014 10:50:16 GMT+0100 (MEZ) -->
     </footer>  
 </div>
 


### PR DESCRIPTION
These two documentation files are both static, so the reference to generation is misleading. In the event that changes in the future, I just commented out the two references.