### PR TITLE
Lod level_changed and Inline load fields

### DIFF
--- a/src/nodes/Navigation/LOD.js
+++ b/src/nodes/Navigation/LOD.js
@@ -41,6 +41,17 @@ x3dom.registerNodeType(
              */
             this.addField_MFFloat(ctx, "range", []);
 
+            /**
+             * outputOnly field which is emitted when the level changes to another range index. When L(d) is activated for display, the LOD node generates a level_changed event with value i where the value of i identifies which value of L was activated for display. Indicates current level of LOD children when activated.
+             * @var {x3dom.fields.SFInt32} level_changed
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.LOD
+             * @initvalue 0
+             * @field x3d
+             * @instance
+             */
+            this.addField_SFInt32(ctx, "level_changed", 0);
+
             this._lastRangePos = -1;
         
         },
@@ -67,6 +78,12 @@ x3dom.registerNodeType(
                 if (i && i >= n) {
                     i = n - 1;
                 }
+              
+                if (i !== this._lastRangePos) {
+                    //x3dom.debug.logInfo('Changed from '+this._lastRangePos+' th range to '+i+' th.');
+                    this.postMessage('level_changed', i);
+                }
+              
                 this._lastRangePos = i;
 
                 var cnode = this._childNodes[i];

--- a/src/nodes/Networking/Inline.js
+++ b/src/nodes/Networking/Inline.js
@@ -75,7 +75,7 @@ x3dom.registerNodeType(
         {
             fieldChanged: function (fieldName)
             {
-                if (fieldName == "url") {
+                if (fieldName == "url" || fieldName == "load") {
 
                     //Remove the childs of the x3domNode
                     for (var i=0; i<this._childNodes.length; i++)
@@ -152,6 +152,11 @@ x3dom.registerNodeType(
 
             loadInline: function ()
             {
+                if (!this._vf.load) {
+                    x3dom.debug.logInfo('Inline: load field prevented loading of ' + this._vf.url[0]);
+                    return;
+                }
+              
                 var that = this;
 
                 var xhr = new window.XMLHttpRequest();


### PR DESCRIPTION
The Lod outputOnly level_changed field can be used for on-demand loading of Inline children among other uses., The Inline load field can be used to prevent immediate downloading, as well as for unloading, simply by Routes.