### PR TITLE
Fixes #879 Point mobileShader test to correct js file.

### DIFF
--- a/test/regression-suite/test/cases/mobileShader/mobileShader.html
+++ b/test/regression-suite/test/cases/mobileShader/mobileShader.html
@@ -4,7 +4,7 @@
     <meta http-equiv='X-UA-Compatible' content='chrome=1'></meta>    
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'></meta>
     <link rel='stylesheet' type='text/css' href='http://www.x3dom.org/download/dev/x3dom.css'></link>
-    <script type='text/javascript' src='http://www.x3dom.org/download/dev/x3dom.js'></script>
+    <script type='text/javascript' src='../../../../x3dom_include.js'></script>
   </head>
   <body>
     <x3d id='x3d' showStat='false' showLog='false' style='width:600px; height:600px; border:0; margin:0; padding:0;' backend='mobile'>


### PR DESCRIPTION
The mobileShader regression test is pointing to the wrong x3dom js file:
`<script type='text/javascript' src='http://www.x3dom.org/download/dev/x3dom.js'></script>`

All the other files in this folder point to:
`<script type="text/javascript" src="../../../../x3dom_include.js"></script>`

Test confirmed working ok after change.