### PR TITLE
BufferGeometry Renaming

### DIFF
--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -313,7 +313,8 @@ x3dom.gfx_webgl = (function() {
             // Check if we need a new shader
             shape._webgl.shader = this.cache.getShaderByProperties(gl, shape, shape.getShaderProperties(viewarea));
 
-            if (!needFullReInit && shape._webgl.binaryGeometry == 0 && shape._webgl.bufferGeometry == 0)    // THINKABOUTME: What about PopGeo & Co.? {
+            if (!needFullReInit && shape._webgl.binaryGeometry == 0 && shape._webgl.bufferGeometry == 0) {
+                // THINKABOUTME: What about PopGeo & Co.?
                 for (q = 0; q < shape._webgl.positions.length; q++) {
                     q6 = 6 * q;
 
@@ -1200,14 +1201,14 @@ x3dom.gfx_webgl = (function() {
                             texture.y = viewport.y;
                             texture.x = texture.x * ratio;
                         }
-                        
+
 						var scale       = viewport.divideComponents( texture );
 						var translation = texture.subtract( viewport ).multiply( 0.5 ).divideComponents( texture );
 					} else {
 						var scale       = new x3dom.fields.SFVec2f(1.0, 1.0);
 						var translation = new x3dom.fields.SFVec2f(0.0, 0.0);
 					}
-					
+
 					sp.scale = scale.toGL();
                     sp.translation = translation.toGL();
                 }

--- a/src/nodes/Geometry3D/BufferAccessor.js
+++ b/src/nodes/Geometry3D/BufferAccessor.js
@@ -9,27 +9,27 @@
 
 /* ### BinaryGeometry ### */
 x3dom.registerNodeType(
-    "BufferGeometryAccessor",
+    "BufferAccessor",
     "Geometry3D",
     defineClass(x3dom.nodeTypes.X3DNode,
-        
+
         /**
-         * Constructor for BufferGeometryAccessor
-         * @constructs x3dom.nodeTypes.BufferGeometryAccessor
+         * Constructor for BufferAccessor
+         * @constructs x3dom.nodeTypes.BufferAccessor
          * @x3d x.x
          * @component Geometry3D
          * @extends x3dom.nodeTypes.X3DNode
          * @param {Object} [ctx=null] - context object, containing initial settings like namespace
-         * @classdesc The BufferGeometryAccessor node is experimental.
+         * @classdesc The BufferGAccessor node is experimental.
          */
         function (ctx) {
-            x3dom.nodeTypes.BufferGeometryAccessor.superClass.call(this, ctx);
+            x3dom.nodeTypes.BufferAccessor.superClass.call(this, ctx);
 
 
             /**
              * The target vertex attribute or vertex index
              * @var {x3dom.fields.SFString} bufferType
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue ""
              * @field x3dom
              * @instance
@@ -39,7 +39,7 @@ x3dom.registerNodeType(
             /**
              * The related buffer view
              * @var {x3dom.fields.SFInt32} view
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -49,7 +49,7 @@ x3dom.registerNodeType(
             /**
              * The buffer byteOffset
              * @var {x3dom.fields.SFInt32} byteOffset
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -59,7 +59,7 @@ x3dom.registerNodeType(
             /**
              * The buffer byteStride
              * @var {x3dom.fields.SFInt32} byteStride
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -69,7 +69,7 @@ x3dom.registerNodeType(
             /**
              * The buffer components
              * @var {x3dom.fields.SFInt32} components
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -79,7 +79,7 @@ x3dom.registerNodeType(
             /**
              * The buffer componentType
              * @var {x3dom.fields.SFInt32} componentType
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 5126
              * @field x3dom
              * @instance
@@ -89,7 +89,7 @@ x3dom.registerNodeType(
             /**
              * The buffer element count
              * @var {x3dom.fields.SFInt32} count
-             * @memberof x3dom.nodeTypes.BufferGeometryAccessor
+             * @memberof x3dom.nodeTypes.BufferAccessor
              * @initvalue 0
              * @field x3dom
              * @instance

--- a/src/nodes/Geometry3D/BufferAccessor.js
+++ b/src/nodes/Geometry3D/BufferAccessor.js
@@ -20,11 +20,10 @@ x3dom.registerNodeType(
          * @component Geometry3D
          * @extends x3dom.nodeTypes.X3DNode
          * @param {Object} [ctx=null] - context object, containing initial settings like namespace
-         * @classdesc The BufferGAccessor node is experimental.
+         * @classdesc The BufferAccessor node is experimental.
          */
         function (ctx) {
             x3dom.nodeTypes.BufferAccessor.superClass.call(this, ctx);
-
 
             /**
              * The target vertex attribute or vertex index

--- a/src/nodes/Geometry3D/BufferGeometry.js
+++ b/src/nodes/Geometry3D/BufferGeometry.js
@@ -12,7 +12,7 @@ x3dom.registerNodeType(
     "BufferGeometry",
     "Geometry3D",
     defineClass(x3dom.nodeTypes.X3DBinaryContainerGeometryNode,
-        
+
         /**
          * Constructor for BufferGeometry
          * @constructs x3dom.nodeTypes.BufferGeometry
@@ -36,16 +36,16 @@ x3dom.registerNodeType(
              */
             this.addField_SFString(ctx, 'buffer', "");
 
-            this.addField_MFNode('views', x3dom.nodeTypes.BufferGeometryView);
-            this.addField_MFNode('accessors', x3dom.nodeTypes.BufferGeometryAccessor);
+            this.addField_MFNode('views', x3dom.nodeTypes.BufferView);
+            this.addField_MFNode('accessors', x3dom.nodeTypes.BufferAccessor);
 
-            this._hasColor = false
-            this._indexed = false
+            this._hasColor = false;
+            this._indexed = false;
         },
         {
             parentAdded: function(parent)
             {
-                
+
             },
 
             nodeChanged: function()

--- a/src/nodes/Geometry3D/BufferView.js
+++ b/src/nodes/Geometry3D/BufferView.js
@@ -9,26 +9,26 @@
 
 /* ### BinaryGeometry ### */
 x3dom.registerNodeType(
-    "BufferGeometryView",
+    "BufferView",
     "Geometry3D",
     defineClass(x3dom.nodeTypes.X3DNode,
-        
+
         /**
-         * Constructor for BufferGeometryView
-         * @constructs x3dom.nodeTypes.BufferGeometryView
+         * Constructor for BufferView
+         * @constructs x3dom.nodeTypes.BufferView
          * @x3d x.x
          * @component Geometry3D
          * @extends x3dom.nodeTypes.X3DNode
          * @param {Object} [ctx=null] - context object, containing initial settings like namespace
-         * @classdesc The BufferGeometryAccessor node is experimental.
+         * @classdesc The BufferAccessor node is experimental.
          */
         function (ctx) {
-            x3dom.nodeTypes.BufferGeometryView.superClass.call(this, ctx);
+            x3dom.nodeTypes.BufferView.superClass.call(this, ctx);
 
             /**
              * The buffer target vertex or index
              * @var {x3dom.fields.SFInt32} target
-             * @memberof x3dom.nodeTypes.BufferGeometryView
+             * @memberof x3dom.nodeTypes.BufferView
              * @initvalue 34962
              * @field x3dom
              * @instance
@@ -38,7 +38,7 @@ x3dom.registerNodeType(
             /**
              * The buffer byteOffset
              * @var {x3dom.fields.SFInt32} byteOffset
-             * @memberof x3dom.nodeTypes.BufferGeometryView
+             * @memberof x3dom.nodeTypes.BufferView
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -48,7 +48,7 @@ x3dom.registerNodeType(
             /**
              * The buffer byteStride
              * @var {x3dom.fields.SFInt32} byteStride
-             * @memberof x3dom.nodeTypes.BufferGeometryView
+             * @memberof x3dom.nodeTypes.BufferView
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -58,7 +58,7 @@ x3dom.registerNodeType(
             /**
              * The buffer byteLength
              * @var {x3dom.fields.SFInt32} byteLength
-             * @memberof x3dom.nodeTypes.BufferGeometryView
+             * @memberof x3dom.nodeTypes.BufferView
              * @initvalue 0
              * @field x3dom
              * @instance
@@ -68,7 +68,7 @@ x3dom.registerNodeType(
             /**
              * The buffer id
              * @var {x3dom.fields.SFInt32} id
-             * @memberof x3dom.nodeTypes.BufferGeometryView
+             * @memberof x3dom.nodeTypes.BufferView
              * @initvalue 0
              * @field x3dom
              * @instance

--- a/src/util/glTF/glTF2Loader.js
+++ b/src/util/glTF/glTF2Loader.js
@@ -1,7 +1,7 @@
 /**
- * 
- * @param {Object} gltf 
- * @param {NodeNameSpace} nameSpace 
+ *
+ * @param {Object} gltf
+ * @param {NodeNameSpace} nameSpace
  */
 x3dom.glTF2Loader = function(nameSpace)
 {
@@ -11,7 +11,7 @@ x3dom.glTF2Loader = function(nameSpace)
 
 /**
  * Starts the loading/parsing of the glTF-Object
- * @param {Object} gltf 
+ * @param {Object} gltf
  */
 x3dom.glTF2Loader.prototype.load = function(input, binary)
 {
@@ -54,7 +54,7 @@ x3dom.glTF2Loader.prototype._traverseNodes = function(node, parent)
         for(var i = 0; i < node.children.length; i++)
         {
             var child = this._gltf.nodes[ node.children[i] ];
-    
+
             this._traverseNodes(child, x3dNode);
         }
     }
@@ -72,7 +72,7 @@ x3dom.glTF2Loader.prototype._generateX3DNode = function(node)
     {
         x3dNode = this._generateX3DMatrixTransform(node);
     }
-    else if( node.translation != undefined || 
+    else if( node.translation != undefined ||
              node.rotation    != undefined ||
              node.scale       != undefined)
     {
@@ -92,7 +92,7 @@ x3dom.glTF2Loader.prototype._generateX3DNode = function(node)
             var shape = this._generateX3DShape(mesh.primitives[i]);
 
             x3dNode.appendChild(shape);
-        } 
+        }
     }
 
     if ( node.name != undefined )
@@ -110,7 +110,7 @@ x3dom.glTF2Loader.prototype._generateX3DNode = function(node)
 x3dom.glTF2Loader.prototype._generateX3DScene = function()
 {
     var scene = document.createElement( "scene" );
-    
+
     return scene;
 };
 
@@ -315,7 +315,7 @@ x3dom.glTF2Loader.prototype._generateX3DPhysicalMaterial = function(material)
             texture = this._gltf.textures[pbr.diffuseTexture.index];
             mat.appendChild(this._generateX3DImageTexture(texture, "baseColorTexture"));
         }
-        
+
         if ( pbr.specularGlossinessTexture )
         {
             texture = this._gltf.textures[pbr.specularGlossinessTexture.index];
@@ -344,11 +344,11 @@ x3dom.glTF2Loader.prototype._generateX3DPhysicalMaterial = function(material)
         texture = this._gltf.textures[material.occlusionTexture.index];
         mat.appendChild(this._generateX3DImageTexture(texture, "occlusionTexture"));
     }
-    
+
     mat.setAttribute("emissiveFactor",  emissiveFactor.join(" "));
     mat.setAttribute("alphaMode",  alphaMode);
     mat.setAttribute("alphaCutoff", alphaCutoff);
-    
+
     return mat;
 };
 
@@ -360,10 +360,10 @@ x3dom.glTF2Loader.prototype._generateX3DPhysicalMaterial = function(material)
  */
 x3dom.glTF2Loader.prototype._generateX3DImageTexture = function(texture, containerField)
 {
-    var image   = this._gltf.images[texture.source]; 
+    var image   = this._gltf.images[texture.source];
 
     var imagetexture = document.createElement("imagetexture");
-    
+
     imagetexture.setAttribute("origChannelCount", "2");
     imagetexture.setAttribute("flipY", "true");
 
@@ -382,7 +382,7 @@ x3dom.glTF2Loader.prototype._generateX3DImageTexture = function(texture, contain
         var sampler = this._gltf.samplers[texture.sampler];
         imagetexture.appendChild(this._createX3DTextureProperties(sampler));
     }
-    
+
 
     return imagetexture;
 };
@@ -407,7 +407,7 @@ x3dom.glTF2Loader.prototype._createX3DTextureProperties = function(sampler)
     {
         textureproperties.setAttribute("generateMipMaps", "true");
     }
-    
+
     return textureproperties;
 };
 
@@ -422,7 +422,7 @@ x3dom.glTF2Loader.prototype._generateX3DBufferGeometry = function(primitive)
     var views = [];
     var bufferGeometry = document.createElement("buffergeometry");
     var centerAndSize = this._getCenterAndSize(primitive);
- 
+
     bufferGeometry.setAttribute("buffer", this._bufferURI(primitive));
     bufferGeometry.setAttribute("position", centerAndSize.center.join( " " ));
     bufferGeometry.setAttribute("size", centerAndSize.size.join( " " ));
@@ -487,7 +487,7 @@ x3dom.glTF2Loader.prototype._generateX3DBufferGeometry = function(primitive)
 
 x3dom.glTF2Loader.prototype._generateX3DBufferView = function(view)
 {
-    var bufferView = document.createElement( "buffergeometryview" );
+    var bufferView = document.createElement( "bufferview" );
 
     bufferView.setAttribute("target",     view.target);
     bufferView.setAttribute("byteOffset", view.byteOffset || 0);
@@ -505,7 +505,7 @@ x3dom.glTF2Loader.prototype._generateX3DBufferAccessor = function(buffer, access
 
     var byteOffset = accessor.byteOffset;
 
-    var bufferAccessor = document.createElement( "buffergeometryaccessor" );
+    var bufferAccessor = document.createElement( "bufferaccessor" );
 
     bufferAccessor.setAttribute("bufferType", buffer.replace("_0", ""));
     bufferAccessor.setAttribute("view", viewID);
@@ -621,7 +621,7 @@ x3dom.glTF2Loader.prototype._primitiveType = function(mode)
 
 x3dom.glTF2Loader.prototype._isDefaultSampler = function(sampler)
 {
-    return ( sampler.wrapS     == 10497 && sampler.wrapS     == 10497 && 
+    return ( sampler.wrapS     == 10497 && sampler.wrapS     == 10497 &&
              sampler.magFilter == 9729  && sampler.minFilter == 9729 );
 };
 
@@ -683,7 +683,7 @@ x3dom.glTF2Loader.prototype._getGLTF = function(input, binary)
                 return gltf;
             }
         }
-    }  
+    }
 };
 
 x3dom.glTF2Loader.prototype._convertBinaryImages = function(gltf, buffer, byteOffset)

--- a/tools/packages.json
+++ b/tools/packages.json
@@ -36,7 +36,7 @@
                 {"path": "MatrixMixer.js"},
                 {"path": "Viewarea.js"},
                 {"path": "Mesh.js"},
-                {"path": "fields.js"},		
+                {"path": "fields.js"},
                 {"path": "Docs.js"},
                 {"path": "util/json/JSONParser.js"},
                 {"path": "util/json/PrototypeExpander.js"}
@@ -269,8 +269,8 @@
                     {"file": "ImageGeometry.js"},
                     {"file": "IndexedFaceSet.js"},
                     {"file": "BufferGeometry.js"},
-                    {"file": "BufferGeometryViews.js"},
-                    {"file": "BufferGeometryAccessor.js"}
+                    {"file": "BufferView.js"},
+                    {"file": "BufferAccessor.js"}
                 ]},
                 {"name": "Texturing3D", "filePrefix": "nodes/Texturing3D/", "files":[
                     {"file": "X3DTexture3DNode.js"},
@@ -381,13 +381,13 @@
                     {"file": "HAnimSegment.js"},
                     {"file": "HAnimSite.js"},
                     {"file": "HAnimHumanoid.js"}
-                ]}              
+                ]}
             ]
 		},
 
 		{"group": "PHYSIC_EXTENSIONS",
             "data": [
-                {"name": "RigidBodyPhysics", "filePrefix": "nodes/RigidBodyPhysics/", "files":[                    
+                {"name": "RigidBodyPhysics", "filePrefix": "nodes/RigidBodyPhysics/", "files":[
                     {"file": "RigidBodyPhysics.js"},
                     {"file": "RigidBodyCollection.js"},
                     {"file": "RigidBody.js"},
@@ -408,7 +408,7 @@
 
         {"group": "COMPRESSED_EXT_LIBS",
                 "data": [
-                    {"name": "Ammo", "filePrefix": "../lib/", "files":[                    
+                    {"name": "Ammo", "filePrefix": "../lib/", "files":[
                         {"file": "ammo.js"}
                     ]}
             ]


### PR DESCRIPTION
Closes #898. 

> Since buffers are used not just for geometry but also other data such as animation data, renaming the BufferGeometryAccessor/View nodes to bufferAccessor/View would allow use of those more generally.

This is just a find and replace renaming of occurrences of
* `BufferGeometryView` to `BufferView`
* `buffergeometryview` to `bufferview`
* `BufferGeometryAccessor` to `BufferAccessor`
* `buffergeometryaccessor` to `bufferaccessor`

Tested various regression-suite tests and the run fine.

As the intention is to re-use the buffer for more than just geometry, I was wondering if you also wanted these files moving out of the `nodes/Geometry3D/` folder? Possibly into a new `nodes/Buffer/` folder? Or into `nodes/Core/`?