### PR TITLE
Texture does not load when authorization required for port different then 80 (Safari)

### DIFF
--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -1293,7 +1293,7 @@ x3dom.Utils.forbiddenBySOP = function (uri_string) {
         Port = Host_Port[1];
     } // else will return false for an invalid URL or URL without authority
 
-    Port = Port || "80";
+    Port = Port || originPort;
     Host = Host || document.location.host;
     Scheme = Scheme || document.location.protocol;
     return !(Port === originPort && Host === document.location.host && Scheme === document.location.protocol);


### PR DESCRIPTION
CrossOrigin was set to "anonymous" when port was different then 80 on domain. It caused that cookie was not send with request about texture.

It did not work only for Safari. 