### PR TITLE
respect 'on' field for env. light

### DIFF
--- a/src/Viewarea.js
+++ b/src/Viewarea.js
@@ -409,9 +409,12 @@ x3dom.Viewarea.prototype.getLightsShadow = function() {
  * @returns {boolean}
  */
 x3dom.Viewarea.prototype.hasPhysicalEnvironmentLight = function () {
+    var light;
     for (var i=0; i<this._doc._nodeBag.lights.length; i++)
     {
-        if (x3dom.isa(this._doc._nodeBag.lights[i], x3dom.nodeTypes.PhysicalEnvironmentLight))
+        var light = this._doc._nodeBag.lights[i];
+        if (x3dom.isa(light, x3dom.nodeTypes.PhysicalEnvironmentLight) &&
+           light._vf.on)
         {
             return true;
         }


### PR DESCRIPTION
in action here:
https://raw.githack.com/andreasplesch/x3dom/a735710b8b184e5807aa0a18ad5e5f7d7fd0076b/test/functional/inline-gltf.html
The headlight control sets 'on' to false, and 'headlight' to true
only in effect for new model, fixed by #926