### PR TITLE
Allowing to define multiple arbitrary MPR planes

### DIFF
--- a/src/nodes/VolumeRendering/MPRPlane.js
+++ b/src/nodes/VolumeRendering/MPRPlane.js
@@ -1,0 +1,107 @@
+/** @namespace x3dom.nodeTypes */
+/*
+ * MEDX3DOM JavaScript Library
+ * http://medx3dom.org
+ *
+ * (C)2019 Vicomtech Research Center,
+ *         Donostia - San Sebastian
+ * Dual licensed under the MIT and GPL.
+ *
+ * Based on code originally provided by
+ * http://www.x3dom.org
+ */
+
+/* ### MPRPlane ### */
+x3dom.registerNodeType(
+    "MPRPlane",
+    "VolumeRendering",
+    defineClass(x3dom.nodeTypes.X3DNode,
+
+        /**
+         * Constructor for a MPRPlane
+         * @constructs x3dom.nodeTypes.MPRPlane
+         * @x3d x.x
+         * @component VolumeRendering
+         * @status experimental
+         * @extends x3dom.nodeTypes.X3DNode
+         * @param {Object} [ctx=null] - context object, containing initial settings like namespace
+         * @classdesc class for defining an arbitrary plane for the MPRVolumeStyle.
+         */
+        function (ctx) {
+            x3dom.nodeTypes.MPRPlane.superClass.call(this, ctx);
+
+            /**
+             * The normal vector of the plane.
+             * @var {x3dom.fields.SFVec3f} normal
+             * @memberof x3dom.nodeTypes.MPRPlane
+             * @initvalue 0.0,1.0,0.0
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFVec3f(ctx, 'normal', 0.0, 1.0, 0.0);
+
+            /**
+             * The position field specifies the position along the plane normal direction where the slice plane is rendered.
+             * @var {x3dom.fields.SFFloat} position
+             * @memberof x3dom.nodeTypes.MPRPlane
+             * @initvalue 0.5
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat(ctx, 'position', 0.5);
+
+            this.uniformVec3fNormal = new x3dom.nodeTypes.Uniform(ctx);
+            this.uniformFloatPosition = new x3dom.nodeTypes.Uniform(ctx);
+            this._planeID = 0; //To differentiate between plane instances
+        },
+        {
+            nodeChanged: function () {
+                if(!this._planeID) {
+                    this._planeID = ++x3dom.nodeTypes.MPRPlane.planeID;
+                }
+            },
+            fieldChanged: function(fieldName) {
+                 switch(fieldName){
+                    case 'position':
+                        this.uniformFloatPosition._vf.value = Math.min(Math.max(this._vf.position, 0.001), 0.999);
+                        this.uniformFloatPosition.fieldChanged("value");
+                        break;
+                    case 'normal':
+                        this.uniformVec3fNormal._vf.value = this._vf.normal;
+                        this.uniformVec3fNormal.fieldChanged("value");
+                        break;
+                }
+            },
+            uniforms: function(){
+                var unis = [];
+
+                this.uniformVec3fNormal._vf.name = 'normalPlane'+this._planeID;
+                this.uniformVec3fNormal._vf.type = 'SFVec3f';
+                this.uniformVec3fNormal._vf.value = this._vf.normal;
+                unis.push(this.uniformVec3fNormal);
+
+                this.uniformFloatPosition._vf.name = 'positionPlane'+this._planeID;
+                this.uniformFloatPosition._vf.type = 'SFFloat';
+                this.uniformFloatPosition._vf.value = this._vf.position;
+                unis.push(this.uniformFloatPosition);
+                return unis;
+            },
+            styleUniformsShaderText: function(){
+              var uniformShaderText = "uniform vec3 normalPlane"+this._planeID+";\n"+
+              "uniform float positionPlane"+this._planeID+";\n";
+              return uniformShaderText;
+            },
+            styleShaderText: function(){
+              var shaderText = "  vec3 pointLine"+this._planeID+" = normalPlane"+this._planeID+"*positionPlane"+this._planeID+";\n"+
+              "  float d"+this._planeID+" = dot(pointLine"+this._planeID+"-ray_pos,normalPlane"+this._planeID+")/dot(dir,normalPlane"+this._planeID+");\n"+
+              "  float f"+this._planeID+" = step(0.0, d"+this._planeID+");\n"+
+              "  d"+this._planeID+" = (1.0 - f"+this._planeID+") * 1000.0 + f"+this._planeID+" * d"+this._planeID+";\n"+
+              "  d = min(d"+this._planeID+",d);\n";
+              return shaderText;
+            }
+        }
+    )
+);
+
+/** Static class ID counter (needed to allow duplicate planes) */
+x3dom.nodeTypes.MPRPlane.planeID = 0;

--- a/tools/packages.json
+++ b/tools/packages.json
@@ -331,6 +331,7 @@
                     {"file": "EdgeEnhancementVolumeStyle.js"},
                     {"file": "IsoSurfaceVolumeData.js"},
                     {"file": "MPRVolumeStyle.js"},
+                    {"file": "MPRPlane.js"},
                     {"file": "OpacityMapVolumeStyle.js"},
                     {"file": "ProjectionVolumeStyle.js"},
                     {"file": "SegmentedVolumeData.js"},


### PR DESCRIPTION
Extension to the _MPRVolumeStyle_ of the volume rendering component that allows to define multiple reconstruction planes using a new node: _MPRPlane_. Refs #944

Example scene witth multiple planes defined:
```xml
<X3D>
    <Scene>
      <Background skyColor='1.0 1.0 1.0'></Background>
      <Viewpoint position='1.9 1.7 -1.4' orientation='0.9 -0.4 0.2 4.1'	zNear='0.001' zFar='100'></Viewpoint>
      <VolumeData id='volume' dimensions='1 1 1' render='true'>
        <ImageTextureAtlas containerField='voxels' url='aorta4096.png' numberOfSlices='96' slicesOverX='10' slicesOverY='10'></ImageTextureAtlas>
        <MPRVolumeStyle forceOpaque="true">
          <MPRPlane normal='0.0 1.0 0.0' position='0.5'></MPRPlane>
          <MPRPlane normal='1.0 0.0 0.0' position='0.5'></MPRPlane>
          <MPRPlane normal='0.0 0.0 1.0' position='0.5'></MPRPlane>
        </MPRVolumeStyle>
      </VolumeData>
    </Scene>
  </X3D>
```