### PR TITLE
Field Color Parse Improvements

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -2455,25 +2455,46 @@ x3dom.fields.SFColor.colorParse = function(color) {
         yellow: 'ffff00',       yellowgreen: '9acd32'
     };
 
-    if (color_names[color]) {
-        // first check if color is given as colorname
-        color = "#" + color_names[color];
+    // Already matches X3D RGB
+    var x3dMatch = /^(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)$/.exec(color);
+    if (x3dMatch !== null) {
+        red   = +x3dMatch[1];
+        green = +x3dMatch[2];
+        blue  = +x3dMatch[3];
     }
 
+    // Matches CSS rgb() function
+    var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(color);
+    if (rgbMatch !== null) {
+        red   = rgbMatch[1] / 255.0;
+        green = rgbMatch[2] / 255.0;
+        blue  = rgbMatch[3] / 255.0;
+    }
+
+    // Matches CSS color name
+    if (color_names[color]) {
+        color = color_names[color];
+    }
+
+    // Hexadecimal color codes
     if (color.substr && color.substr(0, 1) === "#") {
-        color = color.substr(1);
-        var len = color.length;
+        var hex = color.substr(1);
+        var len = hex.length;
 
         if (len === 6) {
-            red   = parseInt("0x" + color.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + color.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + color.substr(4, 2), 16) / 255.0;
+            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
+            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
+            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
         } else if (len === 3) {
-            red   = parseInt("0x" + color.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + color.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + color.substr(2, 1), 16) / 15.0;
+            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
+            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
+            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
         }
     }
+
+    red = red.toFixed(4);
+    green = green.toFixed(4);
+    blue = blue.toFixed(4);
 
     return new x3dom.fields.SFColor(red, green, blue);
 };
@@ -2565,86 +2586,103 @@ x3dom.fields.SFColorRGBA.prototype.toUint = function() {
 x3dom.fields.SFColorRGBA.colorParse = function(color) {
     var red = 0, green = 0, blue = 0, alpha = 0;
 
-    // definition of css color names
-    var color_names = {
-        aliceblue: 'f0f8ff',    antiquewhite: 'faebd7', aqua: '00ffff',
-        aquamarine: '7fffd4',   azure: 'f0ffff',        beige: 'f5f5dc',
-        bisque: 'ffe4c4',       black: '000000',        blanchedalmond: 'ffebcd',
-        blue: '0000ff',         blueviolet: '8a2be2',   brown: 'a52a2a',
-        burlywood: 'deb887',    cadetblue: '5f9ea0',    chartreuse: '7fff00',
-        chocolate: 'd2691e',    coral: 'ff7f50',        cornflowerblue: '6495ed',
-        cornsilk: 'fff8dc',     crimson: 'dc143c',      cyan: '00ffff',
-        darkblue: '00008b',     darkcyan: '008b8b',     darkgoldenrod: 'b8860b',
-        darkgray: 'a9a9a9',     darkgreen: '006400',    darkkhaki: 'bdb76b',
-        darkmagenta: '8b008b',  darkolivegreen: '556b2f',darkorange: 'ff8c00',
-        darkorchid: '9932cc',   darkred: '8b0000',      darksalmon: 'e9967a',
-        darkseagreen: '8fbc8f', darkslateblue: '483d8b',darkslategray: '2f4f4f',
-        darkturquoise: '00ced1',darkviolet: '9400d3',   deeppink: 'ff1493',
-        deepskyblue: '00bfff',  dimgray: '696969',      dodgerblue: '1e90ff',
-        feldspar: 'd19275',     firebrick: 'b22222',    floralwhite: 'fffaf0',
-        forestgreen: '228b22',  fuchsia: 'ff00ff',      gainsboro: 'dcdcdc',
-        ghostwhite: 'f8f8ff',   gold: 'ffd700',         goldenrod: 'daa520',
-        gray: '808080',         green: '008000',        greenyellow: 'adff2f',
-        honeydew: 'f0fff0',     hotpink: 'ff69b4',      indianred : 'cd5c5c',
-        indigo : '4b0082',      ivory: 'fffff0',        khaki: 'f0e68c',
-        lavender: 'e6e6fa',     lavenderblush: 'fff0f5',lawngreen: '7cfc00',
-        lemonchiffon: 'fffacd', lightblue: 'add8e6',    lightcoral: 'f08080',
-        lightcyan: 'e0ffff',    lightgoldenrodyellow: 'fafad2', lightgrey: 'd3d3d3',
-        lightgreen: '90ee90',   lightpink: 'ffb6c1',    lightsalmon: 'ffa07a',
-        lightseagreen: '20b2aa',lightskyblue: '87cefa', lightslateblue: '8470ff',
-        lightslategray: '778899',lightsteelblue: 'b0c4de',lightyellow: 'ffffe0',
-        lime: '00ff00',         limegreen: '32cd32',    linen: 'faf0e6',
-        magenta: 'ff00ff',      maroon: '800000',       mediumaquamarine: '66cdaa',
-        mediumblue: '0000cd',   mediumorchid: 'ba55d3', mediumpurple: '9370d8',
-        mediumseagreen: '3cb371',mediumslateblue: '7b68ee', mediumspringgreen: '00fa9a',
-        mediumturquoise: '48d1cc',mediumvioletred: 'c71585',midnightblue: '191970',
-        mintcream: 'f5fffa',    mistyrose: 'ffe4e1',    moccasin: 'ffe4b5',
-        navajowhite: 'ffdead',  navy: '000080',         oldlace: 'fdf5e6',
-        olive: '808000',        olivedrab: '6b8e23',    orange: 'ffa500',
-        orangered: 'ff4500',    orchid: 'da70d6',       palegoldenrod: 'eee8aa',
-        palegreen: '98fb98',    paleturquoise: 'afeeee',palevioletred: 'd87093',
-        papayawhip: 'ffefd5',   peachpuff: 'ffdab9',    peru: 'cd853f',
-        pink: 'ffc0cb',         plum: 'dda0dd',         powderblue: 'b0e0e6',
-        purple: '800080',       red: 'ff0000',          rosybrown: 'bc8f8f',
-        royalblue: '4169e1',    saddlebrown: '8b4513',  salmon: 'fa8072',
-        sandybrown: 'f4a460',   seagreen: '2e8b57',     seashell: 'fff5ee',
-        sienna: 'a0522d',       silver: 'c0c0c0',       skyblue: '87ceeb',
-        slateblue: '6a5acd',    slategray: '708090',    snow: 'fffafa',
-        springgreen: '00ff7f',  steelblue: '4682b4',    tan: 'd2b48c',
-        teal: '008080',         thistle: 'd8bfd8',      tomato: 'ff6347',
-        turquoise: '40e0d0',    violet: 'ee82ee',       violetred: 'd02090',
-        wheat: 'f5deb3',        white: 'ffffff',        whitesmoke: 'f5f5f5',
-        yellow: 'ffff00',       yellowgreen: '9acd32'
+    // Definition of CSS color names
+    var colorNames = {
+        aliceblue: '#f0f8ff',          antiquewhite: '#faebd7',         aqua: '#00ffff',
+        aquamarine: '#7fffd4',         azure: '#f0ffff',                beige: '#f5f5dc',
+        bisque: '#ffe4c4',             black: '#000000',                blanchedalmond: '#ffebcd',
+        blue: '#0000ff',               blueviolet: '#8a2be2',           brown: '#a52a2a',
+        burlywood: '#deb887',          cadetblue: '#5f9ea0',            chartreuse: '#7fff00',
+        chocolate: '#d2691e',          coral: '#ff7f50',                cornflowerblue: '#6495ed',
+        cornsilk: '#fff8dc',           crimson: '#dc143c',              cyan: '#00ffff',
+        darkblue: '#00008b',           darkcyan: '#008b8b',             darkgoldenrod: '#b8860b',
+        darkgray: '#a9a9a9',           darkgreen: '#006400',            darkkhaki: '#bdb76b',
+        darkmagenta: '#8b008b',        darkolivegreen: '#556b2f',       darkorange: '#ff8c00',
+        darkorchid: '#9932cc',         darkred: '#8b0000',              darksalmon: '#e9967a',
+        darkseagreen: '#8fbc8f',       darkslateblue: '#483d8b',        darkslategray: '#2f4f4f',
+        darkturquoise: '#00ced1',      darkviolet: '#9400d3',           deeppink: '#ff1493',
+        deepskyblue: '#00bfff',        dimgray: '#696969',              dodgerblue: '#1e90ff',
+        feldspar: '#d19275',           firebrick: '#b22222',            floralwhite: '#fffaf0',
+        forestgreen: '#228b22',        fuchsia: '#ff00ff',              gainsboro: '#dcdcdc',
+        ghostwhite: '#f8f8ff',         gold: '#ffd700',                 goldenrod: '#daa520',
+        gray: '#808080',               green: '#008000',                greenyellow: '#adff2f',
+        honeydew: '#f0fff0',           hotpink: '#ff69b4',              indianred : '#cd5c5c',
+        indigo : '#4b0082',            ivory: '#fffff0',                khaki: '#f0e68c',
+        lavender: '#e6e6fa',           lavenderblush: '#fff0f5',        lawngreen: '#7cfc00',
+        lemonchiffon: '#fffacd',       lightblue: '#add8e6',            lightcoral: '#f08080',
+        lightcyan: '#e0ffff',          lightgoldenrodyellow: '#fafad2', lightgrey: '#d3d3d3',
+        lightgreen: '#90ee90',         lightpink: '#ffb6c1',            lightsalmon: '#ffa07a',
+        lightseagreen: '#20b2aa',      lightskyblue: '#87cefa',         lightslateblue: '#8470ff',
+        lightslategray: '#778899',     lightsteelblue: '#b0c4de',       lightyellow: '#ffffe0',
+        lime: '#00ff00',               limegreen: '#32cd32',            linen: '#faf0e6',
+        magenta: '#ff00ff',            maroon: '#800000',               mediumaquamarine: '#66cdaa',
+        mediumblue: '#0000cd',         mediumorchid: '#ba55d3',         mediumpurple: '#9370d8',
+        mediumseagreen: '#3cb371',     mediumslateblue: '#7b68ee',      mediumspringgreen: '#00fa9a',
+        mediumturquoise: '#48d1cc',    mediumvioletred: '#c71585',      midnightblue: '#191970',
+        mintcream: '#f5fffa',          mistyrose: '#ffe4e1',            moccasin: '#ffe4b5',
+        navajowhite: '#ffdead',        navy: '#000080',                 oldlace: '#fdf5e6',
+        olive: '#808000',              olivedrab: '#6b8e23',            orange: '#ffa500',
+        orangered: '#ff4500',          orchid: '#da70d6',               palegoldenrod: '#eee8aa',
+        palegreen: '#98fb98',          paleturquoise: '#afeeee',        palevioletred: '#d87093',
+        papayawhip: '#ffefd5',         peachpuff: '#ffdab9',            peru: '#cd853f',
+        pink: '#ffc0cb',               plum: '#dda0dd',                 powderblue: '#b0e0e6',
+        purple: '#800080',             red: '#ff0000',                  rosybrown: '#bc8f8f',
+        royalblue: '#4169e1',          saddlebrown: '#8b4513',          salmon: '#fa8072',
+        sandybrown: '#f4a460',         seagreen: '#2e8b57',             seashell: '#fff5ee',
+        sienna: '#a0522d',             silver: '#c0c0c0',               skyblue: '#87ceeb',
+        slateblue: '#6a5acd',          slategray: '#708090',            snow: '#fffafa',
+        springgreen: '#00ff7f',        steelblue: '#4682b4',            tan: '#d2b48c',
+        teal: '#008080',               thistle: '#d8bfd8',              tomato: '#ff6347',
+        turquoise: '#40e0d0',          violet: '#ee82ee',               violetred: '#d02090',
+        wheat: '#f5deb3',              white: '#ffffff',                whitesmoke: '#f5f5f5',
+        yellow: '#ffff00',             yellowgreen: '#9acd32'
     };
 
-    if (color_names[color]) {
-        // first check if color is given as colorname
-        color = "#" + color_names[color] + "ff";
+    // Already matches X3D RGB
+    var x3dMatch = /^(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)$/.exec(color);
+    if (x3dMatch !== null) {
+        red = +x3dMatch[1];
+        green = +x3dMatch[2];
+        blue = +x3dMatch[3];
     }
 
+    // Matches CSS rgb() function
+    var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(color);
+    if (rgbMatch !== null) {
+        red   = rgbMatch[1] / 255.0;
+        green = rgbMatch[2] / 255.0;
+        blue  = rgbMatch[3] / 255.0;
+    }
+
+    // Matches CSS color name
+    if (colorNames[color]) {
+        color = colorNames[color];
+    }
+
+    // Hexadecimal color codes
     if (color.substr && color.substr(0, 1) === "#") {
-        color = color.substr(1);
-        var len = color.length;
+        var hex = color.substr(1);
+        var len = hex.length;
 
         if (len === 8) {
-            red   = parseInt("0x" + color.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + color.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + color.substr(4, 2), 16) / 255.0;
-            alpha = parseInt("0x" + color.substr(6, 2), 16) / 255.0;
+            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
+            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
+            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
+            alpha = parseInt("0x" + hex.substr(6, 2), 16) / 255.0;
         } else if (len === 6) {
-            red   = parseInt("0x" + color.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + color.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + color.substr(4, 2), 16) / 255.0;
+            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
+            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
+            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
             alpha = 1.0;
         } else if (len === 4) {
-            red   = parseInt("0x" + color.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + color.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + color.substr(2, 1), 16) / 15.0;
-            alpha = parseInt("0x" + color.substr(3, 1), 16) / 15.0;
+            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
+            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
+            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
+            alpha = parseInt("0x" + hex.substr(3, 1), 16) / 15.0;
         } else if (len === 3) {
-            red   = parseInt("0x" + color.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + color.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + color.substr(2, 1), 16) / 15.0;
+            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
+            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
+            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
             alpha = 1.0;
         }
     }

--- a/src/fields.js
+++ b/src/fields.js
@@ -2632,7 +2632,7 @@ x3dom.fields.SFColorRGBA.colorParse = function(color) {
         red   = rgbaMatch[1] / 255.0;
         green = rgbaMatch[2] / 255.0;
         blue  = rgbaMatch[3] / 255.0;
-        alpha = rgbaMatch[4];
+        alpha = +rgbaMatch[4];
     }
 
     // Matches CSS color name

--- a/src/fields.js
+++ b/src/fields.js
@@ -2308,6 +2308,113 @@ x3dom.fields.Quaternion.prototype.setValueByStr = function(str) {
     return this;
 };
 
+function _colorParse(str) {
+    var red = 0.0, green = 0.0, blue = 0.0;
+    var alpha = 1.0;
+
+    // Definition of CSS color names
+    var colorNames = {
+      aliceblue: '#f0f8ff',          antiquewhite: '#faebd7',         aqua: '#00ffff',
+      aquamarine: '#7fffd4',         azure: '#f0ffff',                beige: '#f5f5dc',
+      bisque: '#ffe4c4',             black: '#000000',                blanchedalmond: '#ffebcd',
+      blue: '#0000ff',               blueviolet: '#8a2be2',           brown: '#a52a2a',
+      burlywood: '#deb887',          cadetblue: '#5f9ea0',            chartreuse: '#7fff00',
+      chocolate: '#d2691e',          coral: '#ff7f50',                cornflowerblue: '#6495ed',
+      cornsilk: '#fff8dc',           crimson: '#dc143c',              cyan: '#00ffff',
+      darkblue: '#00008b',           darkcyan: '#008b8b',             darkgoldenrod: '#b8860b',
+      darkgray: '#a9a9a9',           darkgreen: '#006400',            darkkhaki: '#bdb76b',
+      darkmagenta: '#8b008b',        darkolivegreen: '#556b2f',       darkorange: '#ff8c00',
+      darkorchid: '#9932cc',         darkred: '#8b0000',              darksalmon: '#e9967a',
+      darkseagreen: '#8fbc8f',       darkslateblue: '#483d8b',        darkslategray: '#2f4f4f',
+      darkturquoise: '#00ced1',      darkviolet: '#9400d3',           deeppink: '#ff1493',
+      deepskyblue: '#00bfff',        dimgray: '#696969',              dodgerblue: '#1e90ff',
+      feldspar: '#d19275',           firebrick: '#b22222',            floralwhite: '#fffaf0',
+      forestgreen: '#228b22',        fuchsia: '#ff00ff',              gainsboro: '#dcdcdc',
+      ghostwhite: '#f8f8ff',         gold: '#ffd700',                 goldenrod: '#daa520',
+      gray: '#808080',               green: '#008000',                greenyellow: '#adff2f',
+      honeydew: '#f0fff0',           hotpink: '#ff69b4',              indianred : '#cd5c5c',
+      indigo : '#4b0082',            ivory: '#fffff0',                khaki: '#f0e68c',
+      lavender: '#e6e6fa',           lavenderblush: '#fff0f5',        lawngreen: '#7cfc00',
+      lemonchiffon: '#fffacd',       lightblue: '#add8e6',            lightcoral: '#f08080',
+      lightcyan: '#e0ffff',          lightgoldenrodyellow: '#fafad2', lightgrey: '#d3d3d3',
+      lightgreen: '#90ee90',         lightpink: '#ffb6c1',            lightsalmon: '#ffa07a',
+      lightseagreen: '#20b2aa',      lightskyblue: '#87cefa',         lightslateblue: '#8470ff',
+      lightslategray: '#778899',     lightsteelblue: '#b0c4de',       lightyellow: '#ffffe0',
+      lime: '#00ff00',               limegreen: '#32cd32',            linen: '#faf0e6',
+      magenta: '#ff00ff',            maroon: '#800000',               mediumaquamarine: '#66cdaa',
+      mediumblue: '#0000cd',         mediumorchid: '#ba55d3',         mediumpurple: '#9370d8',
+      mediumseagreen: '#3cb371',     mediumslateblue: '#7b68ee',      mediumspringgreen: '#00fa9a',
+      mediumturquoise: '#48d1cc',    mediumvioletred: '#c71585',      midnightblue: '#191970',
+      mintcream: '#f5fffa',          mistyrose: '#ffe4e1',            moccasin: '#ffe4b5',
+      navajowhite: '#ffdead',        navy: '#000080',                 oldlace: '#fdf5e6',
+      olive: '#808000',              olivedrab: '#6b8e23',            orange: '#ffa500',
+      orangered: '#ff4500',          orchid: '#da70d6',               palegoldenrod: '#eee8aa',
+      palegreen: '#98fb98',          paleturquoise: '#afeeee',        palevioletred: '#d87093',
+      papayawhip: '#ffefd5',         peachpuff: '#ffdab9',            peru: '#cd853f',
+      pink: '#ffc0cb',               plum: '#dda0dd',                 powderblue: '#b0e0e6',
+      purple: '#800080',             red: '#ff0000',                  rosybrown: '#bc8f8f',
+      royalblue: '#4169e1',          saddlebrown: '#8b4513',          salmon: '#fa8072',
+      sandybrown: '#f4a460',         seagreen: '#2e8b57',             seashell: '#fff5ee',
+      sienna: '#a0522d',             silver: '#c0c0c0',               skyblue: '#87ceeb',
+      slateblue: '#6a5acd',          slategray: '#708090',            snow: '#fffafa',
+      springgreen: '#00ff7f',        steelblue: '#4682b4',            tan: '#d2b48c',
+      teal: '#008080',               thistle: '#d8bfd8',              tomato: '#ff6347',
+      turquoise: '#40e0d0',          violet: '#ee82ee',               violetred: '#d02090',
+      wheat: '#f5deb3',              white: '#ffffff',                whitesmoke: '#f5f5f5',
+      yellow: '#ffff00',             yellowgreen: '#9acd32'
+    };
+
+    // Matches CSS rgb() function
+    var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(str);
+    if (rgbMatch !== null) {
+        red   = rgbMatch[1] / 255.0;
+        green = rgbMatch[2] / 255.0;
+        blue  = rgbMatch[3] / 255.0;
+    }
+
+    // Matches CSS rgba() function
+    var rgbaMatch = /^rgba\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3}),(0+\.?\d*|1\.?0*)\)$/.exec(str);
+    if (rgbaMatch !== null) {
+        red   = rgbaMatch[1] / 255.0;
+        green = rgbaMatch[2] / 255.0;
+        blue  = rgbaMatch[3] / 255.0;
+        alpha = +rgbaMatch[4];
+    }
+
+    // Matches CSS color name
+    if (colorNames[str]) {
+        str = colorNames[str];
+    }
+
+    // Hexadecimal color codes
+    if (str.substr && str.substr(0, 1) === "#") {
+        var hex = str.substr(1);
+        var len = hex.length;
+
+        if (len === 8) {
+            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
+            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
+            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
+            alpha = parseInt("0x" + hex.substr(6, 2), 16) / 255.0;
+        } else if (len === 6) {
+            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
+            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
+            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
+        } else if (len === 4) {
+            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
+            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
+            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
+            alpha = parseInt("0x" + hex.substr(3, 1), 16) / 15.0;
+        } else if (len === 3) {
+            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
+            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
+            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
+        }
+    }
+
+    return { r: red, g: green, b: blue, a: alpha };
+}
+
 /**
  * SFColor constructor.
  *
@@ -2401,90 +2508,8 @@ x3dom.fields.SFColor.prototype.setValueByStr = function(str) {
 };
 
 x3dom.fields.SFColor.colorParse = function(color) {
-    var red = 0, green = 0, blue = 0;
-
-    // Definition of CSS color names
-    var colorNames = {
-        aliceblue: '#f0f8ff',          antiquewhite: '#faebd7',         aqua: '#00ffff',
-        aquamarine: '#7fffd4',         azure: '#f0ffff',                beige: '#f5f5dc',
-        bisque: '#ffe4c4',             black: '#000000',                blanchedalmond: '#ffebcd',
-        blue: '#0000ff',               blueviolet: '#8a2be2',           brown: '#a52a2a',
-        burlywood: '#deb887',          cadetblue: '#5f9ea0',            chartreuse: '#7fff00',
-        chocolate: '#d2691e',          coral: '#ff7f50',                cornflowerblue: '#6495ed',
-        cornsilk: '#fff8dc',           crimson: '#dc143c',              cyan: '#00ffff',
-        darkblue: '#00008b',           darkcyan: '#008b8b',             darkgoldenrod: '#b8860b',
-        darkgray: '#a9a9a9',           darkgreen: '#006400',            darkkhaki: '#bdb76b',
-        darkmagenta: '#8b008b',        darkolivegreen: '#556b2f',       darkorange: '#ff8c00',
-        darkorchid: '#9932cc',         darkred: '#8b0000',              darksalmon: '#e9967a',
-        darkseagreen: '#8fbc8f',       darkslateblue: '#483d8b',        darkslategray: '#2f4f4f',
-        darkturquoise: '#00ced1',      darkviolet: '#9400d3',           deeppink: '#ff1493',
-        deepskyblue: '#00bfff',        dimgray: '#696969',              dodgerblue: '#1e90ff',
-        feldspar: '#d19275',           firebrick: '#b22222',            floralwhite: '#fffaf0',
-        forestgreen: '#228b22',        fuchsia: '#ff00ff',              gainsboro: '#dcdcdc',
-        ghostwhite: '#f8f8ff',         gold: '#ffd700',                 goldenrod: '#daa520',
-        gray: '#808080',               green: '#008000',                greenyellow: '#adff2f',
-        honeydew: '#f0fff0',           hotpink: '#ff69b4',              indianred : '#cd5c5c',
-        indigo : '#4b0082',            ivory: '#fffff0',                khaki: '#f0e68c',
-        lavender: '#e6e6fa',           lavenderblush: '#fff0f5',        lawngreen: '#7cfc00',
-        lemonchiffon: '#fffacd',       lightblue: '#add8e6',            lightcoral: '#f08080',
-        lightcyan: '#e0ffff',          lightgoldenrodyellow: '#fafad2', lightgrey: '#d3d3d3',
-        lightgreen: '#90ee90',         lightpink: '#ffb6c1',            lightsalmon: '#ffa07a',
-        lightseagreen: '#20b2aa',      lightskyblue: '#87cefa',         lightslateblue: '#8470ff',
-        lightslategray: '#778899',     lightsteelblue: '#b0c4de',       lightyellow: '#ffffe0',
-        lime: '#00ff00',               limegreen: '#32cd32',            linen: '#faf0e6',
-        magenta: '#ff00ff',            maroon: '#800000',               mediumaquamarine: '#66cdaa',
-        mediumblue: '#0000cd',         mediumorchid: '#ba55d3',         mediumpurple: '#9370d8',
-        mediumseagreen: '#3cb371',     mediumslateblue: '#7b68ee',      mediumspringgreen: '#00fa9a',
-        mediumturquoise: '#48d1cc',    mediumvioletred: '#c71585',      midnightblue: '#191970',
-        mintcream: '#f5fffa',          mistyrose: '#ffe4e1',            moccasin: '#ffe4b5',
-        navajowhite: '#ffdead',        navy: '#000080',                 oldlace: '#fdf5e6',
-        olive: '#808000',              olivedrab: '#6b8e23',            orange: '#ffa500',
-        orangered: '#ff4500',          orchid: '#da70d6',               palegoldenrod: '#eee8aa',
-        palegreen: '#98fb98',          paleturquoise: '#afeeee',        palevioletred: '#d87093',
-        papayawhip: '#ffefd5',         peachpuff: '#ffdab9',            peru: '#cd853f',
-        pink: '#ffc0cb',               plum: '#dda0dd',                 powderblue: '#b0e0e6',
-        purple: '#800080',             red: '#ff0000',                  rosybrown: '#bc8f8f',
-        royalblue: '#4169e1',          saddlebrown: '#8b4513',          salmon: '#fa8072',
-        sandybrown: '#f4a460',         seagreen: '#2e8b57',             seashell: '#fff5ee',
-        sienna: '#a0522d',             silver: '#c0c0c0',               skyblue: '#87ceeb',
-        slateblue: '#6a5acd',          slategray: '#708090',            snow: '#fffafa',
-        springgreen: '#00ff7f',        steelblue: '#4682b4',            tan: '#d2b48c',
-        teal: '#008080',               thistle: '#d8bfd8',              tomato: '#ff6347',
-        turquoise: '#40e0d0',          violet: '#ee82ee',               violetred: '#d02090',
-        wheat: '#f5deb3',              white: '#ffffff',                whitesmoke: '#f5f5f5',
-        yellow: '#ffff00',             yellowgreen: '#9acd32'
-    };
-
-    // Matches CSS rgb() function
-    var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(color);
-    if (rgbMatch !== null) {
-        red   = rgbMatch[1] / 255.0;
-        green = rgbMatch[2] / 255.0;
-        blue  = rgbMatch[3] / 255.0;
-    }
-
-    // Matches CSS color name
-    if (colorNames[color]) {
-        color = colorNames[color];
-    }
-
-    // Hexadecimal color codes
-    if (color.substr && color.substr(0, 1) === "#") {
-        var hex = color.substr(1);
-        var len = hex.length;
-
-        if (len === 6) {
-            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
-        } else if (len === 3) {
-            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
-        }
-    }
-
-    return new x3dom.fields.SFColor(red, green, blue);
+    var rgb = _colorParse(color);
+    return new x3dom.fields.SFColor(rgb.r, rgb.g, rgb.b);
 };
 
 /**
@@ -2572,103 +2597,8 @@ x3dom.fields.SFColorRGBA.prototype.toUint = function() {
 };
 
 x3dom.fields.SFColorRGBA.colorParse = function(color) {
-    var red = 0, green = 0, blue = 0, alpha = 0;
-
-    // Definition of CSS color names
-    var colorNames = {
-        aliceblue: '#f0f8ff',          antiquewhite: '#faebd7',         aqua: '#00ffff',
-        aquamarine: '#7fffd4',         azure: '#f0ffff',                beige: '#f5f5dc',
-        bisque: '#ffe4c4',             black: '#000000',                blanchedalmond: '#ffebcd',
-        blue: '#0000ff',               blueviolet: '#8a2be2',           brown: '#a52a2a',
-        burlywood: '#deb887',          cadetblue: '#5f9ea0',            chartreuse: '#7fff00',
-        chocolate: '#d2691e',          coral: '#ff7f50',                cornflowerblue: '#6495ed',
-        cornsilk: '#fff8dc',           crimson: '#dc143c',              cyan: '#00ffff',
-        darkblue: '#00008b',           darkcyan: '#008b8b',             darkgoldenrod: '#b8860b',
-        darkgray: '#a9a9a9',           darkgreen: '#006400',            darkkhaki: '#bdb76b',
-        darkmagenta: '#8b008b',        darkolivegreen: '#556b2f',       darkorange: '#ff8c00',
-        darkorchid: '#9932cc',         darkred: '#8b0000',              darksalmon: '#e9967a',
-        darkseagreen: '#8fbc8f',       darkslateblue: '#483d8b',        darkslategray: '#2f4f4f',
-        darkturquoise: '#00ced1',      darkviolet: '#9400d3',           deeppink: '#ff1493',
-        deepskyblue: '#00bfff',        dimgray: '#696969',              dodgerblue: '#1e90ff',
-        feldspar: '#d19275',           firebrick: '#b22222',            floralwhite: '#fffaf0',
-        forestgreen: '#228b22',        fuchsia: '#ff00ff',              gainsboro: '#dcdcdc',
-        ghostwhite: '#f8f8ff',         gold: '#ffd700',                 goldenrod: '#daa520',
-        gray: '#808080',               green: '#008000',                greenyellow: '#adff2f',
-        honeydew: '#f0fff0',           hotpink: '#ff69b4',              indianred : '#cd5c5c',
-        indigo : '#4b0082',            ivory: '#fffff0',                khaki: '#f0e68c',
-        lavender: '#e6e6fa',           lavenderblush: '#fff0f5',        lawngreen: '#7cfc00',
-        lemonchiffon: '#fffacd',       lightblue: '#add8e6',            lightcoral: '#f08080',
-        lightcyan: '#e0ffff',          lightgoldenrodyellow: '#fafad2', lightgrey: '#d3d3d3',
-        lightgreen: '#90ee90',         lightpink: '#ffb6c1',            lightsalmon: '#ffa07a',
-        lightseagreen: '#20b2aa',      lightskyblue: '#87cefa',         lightslateblue: '#8470ff',
-        lightslategray: '#778899',     lightsteelblue: '#b0c4de',       lightyellow: '#ffffe0',
-        lime: '#00ff00',               limegreen: '#32cd32',            linen: '#faf0e6',
-        magenta: '#ff00ff',            maroon: '#800000',               mediumaquamarine: '#66cdaa',
-        mediumblue: '#0000cd',         mediumorchid: '#ba55d3',         mediumpurple: '#9370d8',
-        mediumseagreen: '#3cb371',     mediumslateblue: '#7b68ee',      mediumspringgreen: '#00fa9a',
-        mediumturquoise: '#48d1cc',    mediumvioletred: '#c71585',      midnightblue: '#191970',
-        mintcream: '#f5fffa',          mistyrose: '#ffe4e1',            moccasin: '#ffe4b5',
-        navajowhite: '#ffdead',        navy: '#000080',                 oldlace: '#fdf5e6',
-        olive: '#808000',              olivedrab: '#6b8e23',            orange: '#ffa500',
-        orangered: '#ff4500',          orchid: '#da70d6',               palegoldenrod: '#eee8aa',
-        palegreen: '#98fb98',          paleturquoise: '#afeeee',        palevioletred: '#d87093',
-        papayawhip: '#ffefd5',         peachpuff: '#ffdab9',            peru: '#cd853f',
-        pink: '#ffc0cb',               plum: '#dda0dd',                 powderblue: '#b0e0e6',
-        purple: '#800080',             red: '#ff0000',                  rosybrown: '#bc8f8f',
-        royalblue: '#4169e1',          saddlebrown: '#8b4513',          salmon: '#fa8072',
-        sandybrown: '#f4a460',         seagreen: '#2e8b57',             seashell: '#fff5ee',
-        sienna: '#a0522d',             silver: '#c0c0c0',               skyblue: '#87ceeb',
-        slateblue: '#6a5acd',          slategray: '#708090',            snow: '#fffafa',
-        springgreen: '#00ff7f',        steelblue: '#4682b4',            tan: '#d2b48c',
-        teal: '#008080',               thistle: '#d8bfd8',              tomato: '#ff6347',
-        turquoise: '#40e0d0',          violet: '#ee82ee',               violetred: '#d02090',
-        wheat: '#f5deb3',              white: '#ffffff',                whitesmoke: '#f5f5f5',
-        yellow: '#ffff00',             yellowgreen: '#9acd32'
-    };
-
-    // Matches CSS rgba() function
-    var rgbaMatch = /^rgba\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3}),(0+\.?\d*|1\.?0*)\)$/.exec(color);
-    if (rgbaMatch !== null) {
-        red   = rgbaMatch[1] / 255.0;
-        green = rgbaMatch[2] / 255.0;
-        blue  = rgbaMatch[3] / 255.0;
-        alpha = +rgbaMatch[4];
-    }
-
-    // Matches CSS color name
-    if (colorNames[color]) {
-        color = colorNames[color];
-    }
-
-    // Hexadecimal color codes
-    if (color.substr && color.substr(0, 1) === "#") {
-        var hex = color.substr(1);
-        var len = hex.length;
-
-        if (len === 8) {
-            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
-            alpha = parseInt("0x" + hex.substr(6, 2), 16) / 255.0;
-        } else if (len === 6) {
-            red   = parseInt("0x" + hex.substr(0, 2), 16) / 255.0;
-            green = parseInt("0x" + hex.substr(2, 2), 16) / 255.0;
-            blue  = parseInt("0x" + hex.substr(4, 2), 16) / 255.0;
-            alpha = 1.0;
-        } else if (len === 4) {
-            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
-            alpha = parseInt("0x" + hex.substr(3, 1), 16) / 15.0;
-        } else if (len === 3) {
-            red   = parseInt("0x" + hex.substr(0, 1), 16) / 15.0;
-            green = parseInt("0x" + hex.substr(1, 1), 16) / 15.0;
-            blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
-            alpha = 1.0;
-        }
-    }
-
-    return new x3dom.fields.SFColorRGBA(red, green, blue, alpha);
+    var rgba = _colorParse(color);
+    return new x3dom.fields.SFColorRGBA(rgba.r, rgba.g, rgba.b, rgba.a);
 };
 
 /**

--- a/src/fields.js
+++ b/src/fields.js
@@ -2403,65 +2403,57 @@ x3dom.fields.SFColor.prototype.setValueByStr = function(str) {
 x3dom.fields.SFColor.colorParse = function(color) {
     var red = 0, green = 0, blue = 0;
 
-    // definition of css color names
-    var color_names = {
-        aliceblue: 'f0f8ff',    antiquewhite: 'faebd7', aqua: '00ffff',
-        aquamarine: '7fffd4',   azure: 'f0ffff',        beige: 'f5f5dc',
-        bisque: 'ffe4c4',       black: '000000',        blanchedalmond: 'ffebcd',
-        blue: '0000ff',         blueviolet: '8a2be2',   brown: 'a52a2a',
-        burlywood: 'deb887',    cadetblue: '5f9ea0',    chartreuse: '7fff00',
-        chocolate: 'd2691e',    coral: 'ff7f50',        cornflowerblue: '6495ed',
-        cornsilk: 'fff8dc',     crimson: 'dc143c',      cyan: '00ffff',
-        darkblue: '00008b',     darkcyan: '008b8b',     darkgoldenrod: 'b8860b',
-        darkgray: 'a9a9a9',     darkgreen: '006400',    darkkhaki: 'bdb76b',
-        darkmagenta: '8b008b',  darkolivegreen: '556b2f',darkorange: 'ff8c00',
-        darkorchid: '9932cc',   darkred: '8b0000',      darksalmon: 'e9967a',
-        darkseagreen: '8fbc8f', darkslateblue: '483d8b',darkslategray: '2f4f4f',
-        darkturquoise: '00ced1',darkviolet: '9400d3',   deeppink: 'ff1493',
-        deepskyblue: '00bfff',  dimgray: '696969',      dodgerblue: '1e90ff',
-        feldspar: 'd19275',     firebrick: 'b22222',    floralwhite: 'fffaf0',
-        forestgreen: '228b22',  fuchsia: 'ff00ff',      gainsboro: 'dcdcdc',
-        ghostwhite: 'f8f8ff',   gold: 'ffd700',         goldenrod: 'daa520',
-        gray: '808080',         green: '008000',        greenyellow: 'adff2f',
-        honeydew: 'f0fff0',     hotpink: 'ff69b4',      indianred : 'cd5c5c',
-        indigo : '4b0082',      ivory: 'fffff0',        khaki: 'f0e68c',
-        lavender: 'e6e6fa',     lavenderblush: 'fff0f5',lawngreen: '7cfc00',
-        lemonchiffon: 'fffacd', lightblue: 'add8e6',    lightcoral: 'f08080',
-        lightcyan: 'e0ffff',    lightgoldenrodyellow: 'fafad2', lightgrey: 'd3d3d3',
-        lightgreen: '90ee90',   lightpink: 'ffb6c1',    lightsalmon: 'ffa07a',
-        lightseagreen: '20b2aa',lightskyblue: '87cefa', lightslateblue: '8470ff',
-        lightslategray: '778899',lightsteelblue: 'b0c4de',lightyellow: 'ffffe0',
-        lime: '00ff00',         limegreen: '32cd32',    linen: 'faf0e6',
-        magenta: 'ff00ff',      maroon: '800000',       mediumaquamarine: '66cdaa',
-        mediumblue: '0000cd',   mediumorchid: 'ba55d3', mediumpurple: '9370d8',
-        mediumseagreen: '3cb371',mediumslateblue: '7b68ee', mediumspringgreen: '00fa9a',
-        mediumturquoise: '48d1cc',mediumvioletred: 'c71585',midnightblue: '191970',
-        mintcream: 'f5fffa',    mistyrose: 'ffe4e1',    moccasin: 'ffe4b5',
-        navajowhite: 'ffdead',  navy: '000080',         oldlace: 'fdf5e6',
-        olive: '808000',        olivedrab: '6b8e23',    orange: 'ffa500',
-        orangered: 'ff4500',    orchid: 'da70d6',       palegoldenrod: 'eee8aa',
-        palegreen: '98fb98',    paleturquoise: 'afeeee',palevioletred: 'd87093',
-        papayawhip: 'ffefd5',   peachpuff: 'ffdab9',    peru: 'cd853f',
-        pink: 'ffc0cb',         plum: 'dda0dd',         powderblue: 'b0e0e6',
-        purple: '800080',       red: 'ff0000',          rosybrown: 'bc8f8f',
-        royalblue: '4169e1',    saddlebrown: '8b4513',  salmon: 'fa8072',
-        sandybrown: 'f4a460',   seagreen: '2e8b57',     seashell: 'fff5ee',
-        sienna: 'a0522d',       silver: 'c0c0c0',       skyblue: '87ceeb',
-        slateblue: '6a5acd',    slategray: '708090',    snow: 'fffafa',
-        springgreen: '00ff7f',  steelblue: '4682b4',    tan: 'd2b48c',
-        teal: '008080',         thistle: 'd8bfd8',      tomato: 'ff6347',
-        turquoise: '40e0d0',    violet: 'ee82ee',       violetred: 'd02090',
-        wheat: 'f5deb3',        white: 'ffffff',        whitesmoke: 'f5f5f5',
-        yellow: 'ffff00',       yellowgreen: '9acd32'
+    // Definition of CSS color names
+    var colorNames = {
+        aliceblue: '#f0f8ff',          antiquewhite: '#faebd7',         aqua: '#00ffff',
+        aquamarine: '#7fffd4',         azure: '#f0ffff',                beige: '#f5f5dc',
+        bisque: '#ffe4c4',             black: '#000000',                blanchedalmond: '#ffebcd',
+        blue: '#0000ff',               blueviolet: '#8a2be2',           brown: '#a52a2a',
+        burlywood: '#deb887',          cadetblue: '#5f9ea0',            chartreuse: '#7fff00',
+        chocolate: '#d2691e',          coral: '#ff7f50',                cornflowerblue: '#6495ed',
+        cornsilk: '#fff8dc',           crimson: '#dc143c',              cyan: '#00ffff',
+        darkblue: '#00008b',           darkcyan: '#008b8b',             darkgoldenrod: '#b8860b',
+        darkgray: '#a9a9a9',           darkgreen: '#006400',            darkkhaki: '#bdb76b',
+        darkmagenta: '#8b008b',        darkolivegreen: '#556b2f',       darkorange: '#ff8c00',
+        darkorchid: '#9932cc',         darkred: '#8b0000',              darksalmon: '#e9967a',
+        darkseagreen: '#8fbc8f',       darkslateblue: '#483d8b',        darkslategray: '#2f4f4f',
+        darkturquoise: '#00ced1',      darkviolet: '#9400d3',           deeppink: '#ff1493',
+        deepskyblue: '#00bfff',        dimgray: '#696969',              dodgerblue: '#1e90ff',
+        feldspar: '#d19275',           firebrick: '#b22222',            floralwhite: '#fffaf0',
+        forestgreen: '#228b22',        fuchsia: '#ff00ff',              gainsboro: '#dcdcdc',
+        ghostwhite: '#f8f8ff',         gold: '#ffd700',                 goldenrod: '#daa520',
+        gray: '#808080',               green: '#008000',                greenyellow: '#adff2f',
+        honeydew: '#f0fff0',           hotpink: '#ff69b4',              indianred : '#cd5c5c',
+        indigo : '#4b0082',            ivory: '#fffff0',                khaki: '#f0e68c',
+        lavender: '#e6e6fa',           lavenderblush: '#fff0f5',        lawngreen: '#7cfc00',
+        lemonchiffon: '#fffacd',       lightblue: '#add8e6',            lightcoral: '#f08080',
+        lightcyan: '#e0ffff',          lightgoldenrodyellow: '#fafad2', lightgrey: '#d3d3d3',
+        lightgreen: '#90ee90',         lightpink: '#ffb6c1',            lightsalmon: '#ffa07a',
+        lightseagreen: '#20b2aa',      lightskyblue: '#87cefa',         lightslateblue: '#8470ff',
+        lightslategray: '#778899',     lightsteelblue: '#b0c4de',       lightyellow: '#ffffe0',
+        lime: '#00ff00',               limegreen: '#32cd32',            linen: '#faf0e6',
+        magenta: '#ff00ff',            maroon: '#800000',               mediumaquamarine: '#66cdaa',
+        mediumblue: '#0000cd',         mediumorchid: '#ba55d3',         mediumpurple: '#9370d8',
+        mediumseagreen: '#3cb371',     mediumslateblue: '#7b68ee',      mediumspringgreen: '#00fa9a',
+        mediumturquoise: '#48d1cc',    mediumvioletred: '#c71585',      midnightblue: '#191970',
+        mintcream: '#f5fffa',          mistyrose: '#ffe4e1',            moccasin: '#ffe4b5',
+        navajowhite: '#ffdead',        navy: '#000080',                 oldlace: '#fdf5e6',
+        olive: '#808000',              olivedrab: '#6b8e23',            orange: '#ffa500',
+        orangered: '#ff4500',          orchid: '#da70d6',               palegoldenrod: '#eee8aa',
+        palegreen: '#98fb98',          paleturquoise: '#afeeee',        palevioletred: '#d87093',
+        papayawhip: '#ffefd5',         peachpuff: '#ffdab9',            peru: '#cd853f',
+        pink: '#ffc0cb',               plum: '#dda0dd',                 powderblue: '#b0e0e6',
+        purple: '#800080',             red: '#ff0000',                  rosybrown: '#bc8f8f',
+        royalblue: '#4169e1',          saddlebrown: '#8b4513',          salmon: '#fa8072',
+        sandybrown: '#f4a460',         seagreen: '#2e8b57',             seashell: '#fff5ee',
+        sienna: '#a0522d',             silver: '#c0c0c0',               skyblue: '#87ceeb',
+        slateblue: '#6a5acd',          slategray: '#708090',            snow: '#fffafa',
+        springgreen: '#00ff7f',        steelblue: '#4682b4',            tan: '#d2b48c',
+        teal: '#008080',               thistle: '#d8bfd8',              tomato: '#ff6347',
+        turquoise: '#40e0d0',          violet: '#ee82ee',               violetred: '#d02090',
+        wheat: '#f5deb3',              white: '#ffffff',                whitesmoke: '#f5f5f5',
+        yellow: '#ffff00',             yellowgreen: '#9acd32'
     };
-
-    // Already matches X3D RGB
-    var x3dMatch = /^(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)$/.exec(color);
-    if (x3dMatch !== null) {
-        red   = +x3dMatch[1];
-        green = +x3dMatch[2];
-        blue  = +x3dMatch[3];
-    }
 
     // Matches CSS rgb() function
     var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(color);
@@ -2472,8 +2464,8 @@ x3dom.fields.SFColor.colorParse = function(color) {
     }
 
     // Matches CSS color name
-    if (color_names[color]) {
-        color = color_names[color];
+    if (colorNames[color]) {
+        color = colorNames[color];
     }
 
     // Hexadecimal color codes
@@ -2491,10 +2483,6 @@ x3dom.fields.SFColor.colorParse = function(color) {
             blue  = parseInt("0x" + hex.substr(2, 1), 16) / 15.0;
         }
     }
-
-    red = red.toFixed(4);
-    green = green.toFixed(4);
-    blue = blue.toFixed(4);
 
     return new x3dom.fields.SFColor(red, green, blue);
 };
@@ -2638,20 +2626,13 @@ x3dom.fields.SFColorRGBA.colorParse = function(color) {
         yellow: '#ffff00',             yellowgreen: '#9acd32'
     };
 
-    // Already matches X3D RGB
-    var x3dMatch = /^(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)\s+(0+\.?\d*|1\.?0*)$/.exec(color);
-    if (x3dMatch !== null) {
-        red = +x3dMatch[1];
-        green = +x3dMatch[2];
-        blue = +x3dMatch[3];
-    }
-
-    // Matches CSS rgb() function
-    var rgbMatch = /^rgb\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3})\)$/.exec(color);
-    if (rgbMatch !== null) {
-        red   = rgbMatch[1] / 255.0;
-        green = rgbMatch[2] / 255.0;
-        blue  = rgbMatch[3] / 255.0;
+    // Matches CSS rgba() function
+    var rgbaMatch = /^rgba\((\d{1,3}),\s{0,1}(\d{1,3}),\s{0,1}(\d{1,3}),(0+\.?\d*|1\.?0*)\)$/.exec(color);
+    if (rgbaMatch !== null) {
+        red   = rgbaMatch[1] / 255.0;
+        green = rgbaMatch[2] / 255.0;
+        blue  = rgbaMatch[3] / 255.0;
+        alpha = rgbaMatch[4];
     }
 
     // Matches CSS color name


### PR DESCRIPTION
This PR makes improvements to the color parse functions:
* Adds parsing support for `rgb()` and `rgba()` CSS colors.
* Makes more DRY.
* Consolidate `fields.SFColor.colorParse()` and `fields.SFColorRGBA.colorParse()` to single function.
* Slight tidy of variables. 
