### PR TITLE
PixelTexture auto channel count

### DIFF
--- a/src/Texture.js
+++ b/src/Texture.js
@@ -304,6 +304,9 @@ x3dom.Texture.prototype.updateTexture = function() {
         }
     }
     else if (x3dom.isa(tex, x3dom.nodeTypes.PixelTexture)) {
+        
+        if (tex._vf.origChannelCount == 0) tex.setOrigChannelCount(tex._vf.image.comp);
+        
         if (this.texture == null) {
             if (this.node._DEF) {
                 this.texture = this.cache.getTexture2DByDEF(gl, this.node._nameSpace, this.node._DEF);

--- a/src/nodes/Texturing/PixelTexture.js
+++ b/src/nodes/Texturing/PixelTexture.js
@@ -39,13 +39,6 @@ x3dom.registerNodeType(
         
         },
         {
-            fieldChanged: function(fieldName)
-            {
-                if (fieldName == "image") {
-                    this.invalidateGLObject();
-                }
-            },
-
             getWidth: function() {
                 return this._vf.image.width;
             },

--- a/src/nodes/Texturing/X3DTextureNode.js
+++ b/src/nodes/Texturing/X3DTextureNode.js
@@ -202,7 +202,8 @@ x3dom.registerNodeType(
             {
                 if (fieldName == "url" || fieldName ==  "origChannelCount" ||
                     fieldName == "repeatS" || fieldName == "repeatT" ||
-                    fieldName == "scale" || fieldName == "crossOrigin")
+                    fieldName == "scale" || fieldName == "crossOrigin" ||
+                    fieldName == "image")
                 {
                     var that = this;
 

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -18,12 +18,12 @@
   <body>
     <x3d>
       <scene DEF='scene'>
-		  <Viewpoint position="-0.26646 4.58870 15.94134" orientation="-0.99834 -0.05760 0.00260 0.28072"></Viewpoint>
+		  <viewpoint position="-0.26646 4.58870 15.94134" orientation="-0.99834 -0.05760 0.00260 0.28072"></viewpoint>
 		  <transform translation='-10 -2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
-				<pixeltexture image="2 2 1 0xFF 0x00 0x00 0xFF"></pixeltexture>
+				<material def='gold' diffuseColor='0.9 0.7 0.2'></material>
+				<pixeltexture def='pxtex' image="2 2 1 0xff 0x00 0x00 0xff"></pixeltexture>
 			  </appearance>
 			  <box></box>
 			</shape>
@@ -31,8 +31,8 @@
 		  <transform translation='-6 -2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
-				<imageTexture  url='"jpeg-gray.jpg"'></imageTexture>
+				<material use='gold'></material>
+				<imageTexture def='jpgtex' url='"jpeg-gray.jpg"'></imageTexture>
 			  </appearance>
 			  <box></box>
 			</shape>
@@ -40,8 +40,8 @@
 		  <transform translation='-2 -2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
-				<imageTexture url='"png-gray.png"'></imageTexture>
+				<material use='gold'></material>
+				<imageTexture def='pngtex' url='"png-gray.png"'></imageTexture>
 			  </appearance>
 			  <box></box>
 			</shape>
@@ -49,8 +49,8 @@
 		  <transform translation='2 -2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
-				<imageTexture  url='"gif-gray.gif"'></imageTexture>
+				<material use='gold'></material>
+				<imageTexture def='giftex' url='"gif-gray.gif"'></imageTexture>
 			  </appearance>
 			  <box></box>
 			</shape>
@@ -58,13 +58,58 @@
 		  <transform translation='6 -2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
-				<imageTexture url='"dds-gray.dds"'></imageTexture>
+				<material use='gold'></material>
+				<imageTexture def='ddstex' url='"dds-gray.dds"'></imageTexture>
 			  </appearance>
 			  <box></box>
 			</shape>
 		  </transform>
-
+          
+          <transform translation='-10 -6 0'>
+			<shape>
+			  <appearance>
+				<material def='lgreen' diffuseColor='0.74 0.97 0.79'></material>
+				<pixeltexture use='pxtex'></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
+		  <transform translation='-6 -6 0'>
+			<shape>
+			  <appearance>
+				<material use='lgreen'></material>
+				<pixeltexture use='jpgtex'></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
+		  <transform translation='-2 -6 0'>
+			<shape>
+			  <appearance>
+				<material use='lgreen'></material>
+				<pixeltexture use='pngtex'></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
+		  <transform translation='2 -6 0'>
+			<shape>
+			  <appearance>
+				<material use='lgreen'></material>
+				<pixeltexture use='giftex'></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
+		  <transform translation='6 -6 0'>
+			<shape>
+			  <appearance>
+				<material use='lgreen'></material>
+				<pixeltexture use='ddstex'></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
 
 		  <transform translation='-10 2 0'>
 			<shape>

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -65,7 +65,7 @@
 			</shape>
 		  </transform>
           
-          <transform translation='-10 -6 0'>
+		  <transform translation='-10 -6 0'>
 			<shape>
 			  <appearance>
 				<material def='lgreen' diffuseColor='0.74 0.97 0.79'></material>

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -19,6 +19,15 @@
     <x3d>
       <scene DEF='scene'>
 		  <Viewpoint position="-0.26646 4.58870 15.94134" orientation="-0.99834 -0.05760 0.00260 0.28072"></Viewpoint>
+		  <transform translation='-10 -2 0'>
+			<shape>
+			  <appearance>
+				<material diffuseColor='0.9 0.7 0.2'></material>
+				<PixelTexture  image="2 2 1 0xFF 0x80 0xFF 0x80"></PixelTexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
 		  <transform translation='-6 -2 0'>
 			<shape>
 			  <appearance>

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -23,7 +23,7 @@
 			<shape>
 			  <appearance>
 				<material diffuseColor='0.9 0.7 0.2'></material>
-				<PixelTexture  image="2 2 1 0xFF 0x80 0xFF 0x80"></PixelTexture>
+				<pixeltexture image="2 2 1 0xFF 0x00 0x00 0xFF"></pixeltexture>
 			  </appearance>
 			  <box></box>
 			</shape>
@@ -66,6 +66,15 @@
 		  </transform>
 
 
+		  <transform translation='-10 2 0'>
+			<shape>
+			  <appearance>
+				<material diffuseColor='0.9 0.7 0.2'></material>
+				<pixeltexture image="2 2 4 0xFF000000 0x0000FF80 0x0000FF80 0xFF000000"></pixeltexture>
+			  </appearance>
+			  <box></box>
+			</shape>
+		  </transform>
 		  <transform translation='-6 2 0'>
 			<shape>
 			  <appearance>

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -70,7 +70,7 @@
 			<shape>
 			  <appearance>
 				<material diffuseColor='0.9 0.7 0.2'></material>
-				<pixeltexture image="2 2 4 0xFF000000 0x0000FF80 0x0000FF80 0xFF000000"></pixeltexture>
+				<pixeltexture image="2 2 3 0xff0000 0x0000ff 0x0000ff 0xff0000"></pixeltexture>
 			  </appearance>
 			  <box></box>
 			</shape>

--- a/test/functional/channelCount/index.html
+++ b/test/functional/channelCount/index.html
@@ -114,7 +114,7 @@
 		  <transform translation='-10 2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
+				<material use='gold'></material>
 				<pixeltexture image="2 2 3 0xff0000 0x0000ff 0x0000ff 0xff0000"></pixeltexture>
 			  </appearance>
 			  <box></box>
@@ -123,7 +123,7 @@
 		  <transform translation='-6 2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
+				<material use='gold'></material>
 				<imageTexture  url='"jpeg-color.jpg"'></imageTexture>
 			  </appearance>
 			  <box></box>
@@ -132,7 +132,7 @@
 		  <transform translation='-2 2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
+				<material use='gold'></material>
 				<imageTexture url='"png-color.png"'></imageTexture>
 			  </appearance>
 			  <box></box>
@@ -141,7 +141,7 @@
 		  <transform translation='2 2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
+				<material use='gold'></material>
 				<imageTexture  url='"gif-color.gif"'></imageTexture>
 			  </appearance>
 			  <box></box>
@@ -150,7 +150,7 @@
 		  <transform translation='6 2 0'>
 			<shape>
 			  <appearance>
-				<material diffuseColor='0.9 0.7 0.2'></material>
+				<material use='gold'></material>
 				<imageTexture url='"dds-color.dds"'></imageTexture>
 			  </appearance>
 			  <box></box>


### PR DESCRIPTION
use pixel texture image component number as origChannelCount if not provided. See example:
https://raw.githack.com/x3dom/x3dom/b7f18aa70bd3501066b4b95b710a4afe408cbf67/test/functional/channelCount/index.html