### PR TITLE
Add PointProperties Support

### DIFF
--- a/src/nodes/Shape/Appearance.js
+++ b/src/nodes/Shape/Appearance.js
@@ -72,6 +72,16 @@ x3dom.registerNodeType(
             this.addField_SFNode( "lineProperties", x3dom.nodeTypes.LineProperties );
 
             /**
+             * The pointProperties field, if specified, shall contain a PointProperties node. If pointProperties is NULL or unspecified, the pointProperties field has no effect.
+             * @var {x3dom.fields.SFNode} pointProperties
+             * @memberof x3dom.nodeTypes.Appearance
+             * @initvalue x3dom.nodeTypes.PointProperties
+             * @field x3d
+             * @instance
+             */
+            this.addField_SFNode( "pointProperties", x3dom.nodeTypes.PointProperties );
+
+            /**
              * Holds a ColorMaskMode node.
              * @var {x3dom.fields.SFNode} colorMaskMode
              * @memberof x3dom.nodeTypes.Appearance

--- a/src/nodes/Shape/PointProperties.js
+++ b/src/nodes/Shape/PointProperties.js
@@ -90,7 +90,7 @@ x3dom.registerNodeType(
              *
              * @var {["POINT_COLOR", "TEXTURE_COLOR", "TEXTURE_AND_POINT_COLOR"]} colorMode
              * @memberof x3dom.nodeTypes.PointProperties
-             * @initvalue true
+             * @initvalue "POINT_COLOR"
              * @field x3d
              * @instance
              */

--- a/src/nodes/Shape/PointProperties.js
+++ b/src/nodes/Shape/PointProperties.js
@@ -1,0 +1,67 @@
+/** @namespace x3dom.nodeTypes */
+/*
+ * X3DOM JavaScript Library
+ * http://www.x3dom.org
+ *
+ * (C)2009 Fraunhofer IGD, Darmstadt, Germany
+ * Dual licensed under the MIT and GPL
+ */
+
+/* ### LineProperties ### */
+x3dom.registerNodeType(
+    "LineProperties",
+    "Shape",
+    defineClass( x3dom.nodeTypes.X3DAppearanceChildNode,
+
+        /**
+         * Constructor for LineProperties
+         * @constructs x3dom.nodeTypes.LineProperties
+         * @x3d 3.3
+         * @component Shape
+         * @status experimental
+         * @extends x3dom.nodeTypes.X3DAppearanceChildNode
+         * @param {Object} [ctx=null] - context object, containing initial settings like namespace
+         * @classdesc The LineProperties node specifies additional properties to be applied to all line geometry. The colour of the line is specified by the associated Material node.
+         */
+        function ( ctx )
+        {
+            x3dom.nodeTypes.LineProperties.superClass.call( this, ctx );
+
+            // http://www.web3d.org/files/specifications/19775-1/V3.2/Part01/components/shape.html#LineProperties
+            // THINKABOUTME: to my mind, the only useful, but missing, field is linewidth (scaleFactor is overhead)
+
+            /**
+             * The linetype and linewidth shall only be applied when the applied field has value TRUE.
+             * When the value of the applied field is FALSE, a solid line of nominal width shall be produced.
+             * @var {x3dom.fields.SFBool} applied
+             * @memberof x3dom.nodeTypes.LineProperties
+             * @initvalue true
+             * @field x3d
+             * @instance
+             */
+            this.addField_SFBool( ctx, "applied", true );
+
+            /**
+             * The linetype field selects a line pattern.
+             * @var {x3dom.fields.SFInt32} linetype
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.LineProperties
+             * @initvalue 1
+             * @field x3d
+             * @instance
+             */
+            this.addField_SFInt32( ctx, "linetype", 1 );
+
+            /**
+             * The linewidthScaleFactor is a multiplicative value that scales a the linewidth. This resulting value shall then be mapped to the nearest available line width. A value less than or equal to zero refers to the minimum available line width.
+             * @var {x3dom.fields.SFFloat} linewidthScaleFactor
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.LineProperties
+             * @initvalue 0
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat( ctx, "linewidthScaleFactor", 0 );
+        }
+    )
+);

--- a/src/nodes/Shape/PointProperties.js
+++ b/src/nodes/Shape/PointProperties.js
@@ -7,61 +7,94 @@
  * Dual licensed under the MIT and GPL
  */
 
-/* ### LineProperties ### */
+/* ### PointProperties ### */
 x3dom.registerNodeType(
-    "LineProperties",
+    "PointProperties",
     "Shape",
     defineClass( x3dom.nodeTypes.X3DAppearanceChildNode,
 
         /**
-         * Constructor for LineProperties
-         * @constructs x3dom.nodeTypes.LineProperties
+         * Constructor for PointProperties
+         * @constructs x3dom.nodeTypes.PointProperties
          * @x3d 3.3
          * @component Shape
          * @status experimental
          * @extends x3dom.nodeTypes.X3DAppearanceChildNode
          * @param {Object} [ctx=null] - context object, containing initial settings like namespace
-         * @classdesc The LineProperties node specifies additional properties to be applied to all line geometry. The colour of the line is specified by the associated Material node.
+         * @classdesc The PointProperties node specifies additional properties to be applied to all points.
          */
         function ( ctx )
         {
-            x3dom.nodeTypes.LineProperties.superClass.call( this, ctx );
+            x3dom.nodeTypes.PointProperties.superClass.call( this, ctx );
 
-            // http://www.web3d.org/files/specifications/19775-1/V3.2/Part01/components/shape.html#LineProperties
-            // THINKABOUTME: to my mind, the only useful, but missing, field is linewidth (scaleFactor is overhead)
+            // https://www.web3d.org/specifications/X3dSchemaDocumentation4.0/x3d-4.0_PointProperties.html
 
             /**
-             * The linetype and linewidth shall only be applied when the applied field has value TRUE.
-             * When the value of the applied field is FALSE, a solid line of nominal width shall be produced.
-             * @var {x3dom.fields.SFBool} applied
-             * @memberof x3dom.nodeTypes.LineProperties
+             * Nominal rendered point size is a browser-dependent minimum renderable point size, which is then multiplied by an additional (greater than or equal to 1.0) pointSizeScaleFactor.
+             * Hint: Additional sizing modifications are determined by pointSizeMinValue, pointSizeMaxValue, and pointSizeAttenuation array.
+             *
+             * @var {x3dom.fields.SFFloat} pointSizeScaleFactor
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.PointProperties
+             * @initvalue 1
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat( ctx, "pointSizeScaleFactor", 1 );
+
+            /**
+             * PointSizeMinValue is minimum allowed scaling factor on nominal browser point scaling.
+             * Warning: Maintain pointSizeMinValue <= pointSizeMaxValue.
+             *
+             * @var {x3dom.fields.SFFloat} pointSizeMinValue
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.PointProperties
+             * @initvalue 1
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat( ctx, "pointSizeMinValue", 1 );
+
+            /**
+             * PointSizeMaxValue is maximum allowed scaling factor on nominal browser point scaling.
+             * Warning: Maintain pointSizeMinValue <= pointSizeMaxValue.
+             *
+             * @var {x3dom.fields.SFFloat} pointSizeMaxValue
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.PointProperties
+             * @initvalue 1
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat( ctx, "pointSizeMaxValue", 1 );
+
+            /**
+             * PointSizeAttenuation array values [a, b, c] are set to default values if undefined. Together these parameters define attenuation factor 1/(a + b×r + c×r^2) where r is the distance from observer position (current viewpoint) to each point.
+             * Hint: Nominal point size is multiplied by attenuation factor and then clipped to a minimum value of pointSizeMinValue × minimum renderable point size, then clipped to maximum size of pointSizeMaxValue × minimum renderable point size.
+             *
+             * @var {x3dom.fields.MFFloat} pointSizeAttenuation
+             * @range [0, inf]
+             * @memberof x3dom.nodeTypes.PointProperties
+             * @initvalue 1 0 0
+             * @field x3dom
+             * @instance
+             */
+            this.addField_SFFloat( ctx, "pointSizeAttenuation", 1 );
+
+            /**
+             * ColorMode has blending effect on the rendering of point sprites, applying supplied color (Color node or Material emissiveColor) and texture color.
+             * Hint:
+             * POINT_COLOR shall display the RGB channels of the color instance defined in X3DMaterialNode or X3DColorNode, and the A channel of the texture if any. If no color is associated to the point, the default RGB color (0, 0, 0) shall be used.
+             * TEXTURE_COLOR shall display the original texture with its RGBA channels and regardless to the X3DMaterialNode or X3DColorNode which might be associated to the point set.
+             * TEXTURE_AND_POINT_COLOR shall display the RGBA channels of a texture added to the RGB channels of the color defined in X3DMaterialNode or X3DColorNode node, and the A channel of the texture if any. If no color is associated to the point, the result shall be exactly the same as TEXTURE_COLOR.
+             *
+             * @var {["POINT_COLOR", "TEXTURE_COLOR", "TEXTURE_AND_POINT_COLOR"]} colorMode
+             * @memberof x3dom.nodeTypes.PointProperties
              * @initvalue true
              * @field x3d
              * @instance
              */
-            this.addField_SFBool( ctx, "applied", true );
-
-            /**
-             * The linetype field selects a line pattern.
-             * @var {x3dom.fields.SFInt32} linetype
-             * @range [0, inf]
-             * @memberof x3dom.nodeTypes.LineProperties
-             * @initvalue 1
-             * @field x3d
-             * @instance
-             */
-            this.addField_SFInt32( ctx, "linetype", 1 );
-
-            /**
-             * The linewidthScaleFactor is a multiplicative value that scales a the linewidth. This resulting value shall then be mapped to the nearest available line width. A value less than or equal to zero refers to the minimum available line width.
-             * @var {x3dom.fields.SFFloat} linewidthScaleFactor
-             * @range [0, inf]
-             * @memberof x3dom.nodeTypes.LineProperties
-             * @initvalue 0
-             * @field x3dom
-             * @instance
-             */
-            this.addField_SFFloat( ctx, "linewidthScaleFactor", 0 );
+            this.addField_SFBool( ctx, "colorMode", "TEXTURE_AND_POINT_COLOR" );
         }
     )
 );

--- a/src/nodes/Shape/PointProperties.js
+++ b/src/nodes/Shape/PointProperties.js
@@ -16,7 +16,7 @@ x3dom.registerNodeType(
         /**
          * Constructor for PointProperties
          * @constructs x3dom.nodeTypes.PointProperties
-         * @x3d 3.3
+         * @x3d 4.0
          * @component Shape
          * @status experimental
          * @extends x3dom.nodeTypes.X3DAppearanceChildNode


### PR DESCRIPTION
This PR is attempting to add PointProperties support to x3dom. This proposed v4 node allows the size of PointSet points to be changes. Akin to x3doms ParticleSet.

This has recently been added to x_ite and it would be good to get it added to x3dom also.
http://create3000.de/users-guide/components/shape/pointproperties/

 I know this is only half baked presently and by no means complete, I am only putting this PR out for comment and help to progress. Please can someone give me pointers as to what else I need to add to this diff?