### PR TITLE
Fix bug on unload function

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -233,7 +233,14 @@ x3dom.userAgentFeature = {
         {
             for ( var i = 0; i < x3dom.canvases.length; i++ )
             {
-                x3dom.canvases[ i ].doc.shutdown( x3dom.canvases[ i ].gl );
+                
+                var canvase = x3dom.canvases[ i ];
+            	
+            	if (canvase.doc != null)
+                {
+            		canvase.doc.shutdown(canvase.gl);
+            	}
+                
             }
             x3dom.canvases = [];
         }


### PR DESCRIPTION
Correct the error `x3dom.canvases[i].doc is null`. It was discoveted with Firefox 75.0 x64 For Arch Linux 1.0 when the message "X3DOM is not supported" appears.