### PR TITLE
Undo fix for #1059: incorrect tessellation of rational NURBS

### DIFF
--- a/src/nodes/NURBS/NurbsCurve.js
+++ b/src/nodes/NURBS/NurbsCurve.js
@@ -221,9 +221,9 @@ x3dom.registerNodeType(
                 for ( k = 0; k <= p; k++ )
                 {
                     i = indu + k;
-                    temp[ 0 ] += Nu[ k ] * W[ i ] * P[ i ].x;
-                    temp[ 1 ] += Nu[ k ] * W[ i ] * P[ i ].y;
-                    temp[ 2 ] += Nu[ k ] * W[ i ] * P[ i ].z;
+                    temp[ 0 ] += Nu[ k ] * P[ i ].x;
+                    temp[ 1 ] += Nu[ k ] * P[ i ].y;
+                    temp[ 2 ] += Nu[ k ] * P[ i ].z;
                     temp[ 3 ] += Nu[ k ] * W[ i ];
                 }
 

--- a/src/nodes/NURBS/x3dom-nurbs-web-worker.js
+++ b/src/nodes/NURBS/x3dom-nurbs-web-worker.js
@@ -182,9 +182,9 @@
                 for ( k = 0; k <= p; k++ )
                 {
                     i = indu + k + ( indv * ( n + 1 ) );
-                    temp[ j + 0 ] += Nu[ k ] * W[ i ] * P[ i ].x;
-                    temp[ j + 1 ] += Nu[ k ] * W[ i ] * P[ i ].y;
-                    temp[ j + 2 ] += Nu[ k ] * W[ i ] * P[ i ].z;
+                    temp[ j + 0 ] += Nu[ k ] * P[ i ].x;
+                    temp[ j + 1 ] += Nu[ k ] * P[ i ].y;
+                    temp[ j + 2 ] += Nu[ k ] * P[ i ].z;
                     temp[ j + 3 ] += Nu[ k ] * W[ i ];
                 }
                 j += 4;


### PR DESCRIPTION
Although the X3D specification is not cristal clear, many other X3D viewers
expect the control points to be pre-multiplied. To have that same behavior,
we undo the change, assuming that the control points are pre-multiplied
at authoring time.