### PR TITLE
Remove new Date().getTime() fallback in start-/stopMeasure

### DIFF
--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -38,14 +38,7 @@ x3dom.Utils.startMeasure = function ( name )
     var uname = name.toUpperCase();
     if ( !x3dom.Utils.measurements[ uname ] )
     {
-        if ( performance && performance.now )
-        {
-            x3dom.Utils.measurements[ uname ] = performance.now();
-        }
-        else
-        {
-            x3dom.Utils.measurements[ uname ] = new Date().getTime();
-        }
+        x3dom.Utils.measurements[ uname ] = performance.now();
     }
 };
 
@@ -56,14 +49,7 @@ x3dom.Utils.stopMeasure = function ( name )
     {
         var startTime = x3dom.Utils.measurements[ uname ];
         delete x3dom.Utils.measurements[ uname ];
-        if ( performance && performance.now )
-        {
-            return performance.now() - startTime;
-        }
-        else
-        {
-            return new Date().getTime() - startTime;
-        }
+        return performance.now() - startTime;
     }
     return 0;
 };


### PR DESCRIPTION
as performance.now is always available since https://github.com/x3dom/x3dom/commit/9e1f483d3f8e3e39385a91933d0fec4935d82cef

https://github.com/x3dom/x3dom/blob/9edcd6e2f6fb93bfddad94981131b144242b8889/src/util/Utils.js#L22-L34