### PR TITLE
Replace misspelled onMouseAlt with onMouseOut

### DIFF
--- a/src/X3DCanvas.js
+++ b/src/X3DCanvas.js
@@ -262,7 +262,7 @@ x3dom.X3DCanvas.prototype.bindEventListeners = function ()
         }
     };
 
-    this.onMouseAlt = function ( evt )
+    this.onMouseOut = function ( evt )
     {
         if ( !this.isMulti )
         {


### PR DESCRIPTION
The CSS class `x3dom-canvas-mousedown` changes the cursor from `pointer` to `grabbing`.
The calls is added to the `canvas `in function `onMouseDown `and removed in `onMouseUp` or `onMouseOut `within `x3dom.X3DCanvas.prototype.bindEventListeners`.

However, `onMouseOut` is mispelled as `onMouseAlt`. Therefore the cursor still has form `grabbing` (even if it's not in grabbing mode anymore) when you click down on the canvas, leave the canvas, and enter the canvas again.

Some test cases use `onMouseOut`, too (in the context of individual shapes):

`\test\functional\inlineReflection.html`
Used attributes: `onmouseover`, `onmouseout `
Expected result: The color of the shapes changes depending on position of mouse pointer.

`/test/regression-suite/test/cases/depthVolren/depthVolren.html`
Used attributes: `onmouseover`, `onmouseout `
Expected result: The border of the cut plane changes color depending on the position of the mouse.
(There are some issues with this test case which are not related to the current PR.)

`/test/regression-suite/test/cases/points/points.html`
Used attributes: `onmouseover`, `onmouseout`, `onclick` 
Expected result: "pnt over", "pnd out", and "pnt click" gets displayed if the mouse pointer interacts with points.

-> All tests are ok

Disclaimer: Neither with the old code or the corrected code, the cursor always turn to `grabbing` if you press the mouse right button. I guess that there exist some more issues.