### PR TITLE
Replace 1.5707963 with Math.PI

### DIFF
--- a/src/nodes/Geometry2D/Arc2D.js
+++ b/src/nodes/Geometry2D/Arc2D.js
@@ -60,7 +60,7 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "endAngle", Math.PI/2.0 );
+            this.addField_SFFloat( ctx, "endAngle", Math.PI / 2.0 );
 
             /**
              * Number of lines into which the arc is subdivided

--- a/src/nodes/Geometry2D/Arc2D.js
+++ b/src/nodes/Geometry2D/Arc2D.js
@@ -45,7 +45,7 @@ x3dom.registerNodeType(
              * @var {x3dom.fields.SFFloat} startAngle
              * @memberof x3dom.nodeTypes.Arc2D
              * @initvalue 0
-             * @range [-2 pi, 2pi]
+             * @range [-2 pi, 2 pi]
              * @field x3d
              * @instance
              */
@@ -55,12 +55,12 @@ x3dom.registerNodeType(
              * The arc extends from the startAngle counterclockwise to the endAngle.
              * @var {x3dom.fields.SFFloat} endAngle
              * @memberof x3dom.nodeTypes.Arc2D
-             * @initvalue 1.570796
-             * @range [-2 pi, 2pi]
+             * @initvalue pi/2
+             * @range [-2 pi, 2 pi]
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "endAngle", 1.570796 );
+            this.addField_SFFloat( ctx, "endAngle", Math.PI/2.0 );
 
             /**
              * Number of lines into which the arc is subdivided

--- a/src/nodes/Geometry2D/ArcClose2D.js
+++ b/src/nodes/Geometry2D/ArcClose2D.js
@@ -71,7 +71,7 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "endAngle", Math.PI/2.0 );
+            this.addField_SFFloat( ctx, "endAngle", Math.PI / 2.0 );
 
             /**
              * Number of lines into which the arc is subdivided

--- a/src/nodes/Geometry2D/ArcClose2D.js
+++ b/src/nodes/Geometry2D/ArcClose2D.js
@@ -56,7 +56,7 @@ x3dom.registerNodeType(
              * @var {x3dom.fields.SFFloat} startAngle
              * @memberof x3dom.nodeTypes.Arc2D
              * @initvalue 0
-             * @range [-2 pi, 2pi]
+             * @range [-2 pi, 2 pi]
              * @field x3d
              * @instance
              */
@@ -66,12 +66,12 @@ x3dom.registerNodeType(
              * The arc extends from the startAngle counterclockwise to the endAngle.
              * @var {x3dom.fields.SFFloat} endAngle
              * @memberof x3dom.nodeTypes.Arc2D
-             * @initvalue 1.570796
-             * @range [-2 pi, 2pi]
+             * @initvalue pi/2
+             * @range [-2 pi, 2 pi]
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "endAngle", 1.570796 );
+            this.addField_SFFloat( ctx, "endAngle", Math.PI/2.0 );
 
             /**
              * Number of lines into which the arc is subdivided

--- a/src/nodes/Lighting/SpotLight.js
+++ b/src/nodes/Lighting/SpotLight.js
@@ -90,7 +90,7 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "beamWidth", Math.PI/2.0 );
+            this.addField_SFFloat( ctx, "beamWidth", Math.PI / 2.0 );
 
             /**
              * The cutOffAngle field specifies the outer bound of the solid angle. The light source does not emit light outside of this solid angle.
@@ -103,7 +103,7 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "cutOffAngle", Math.PI/2.0 );
+            this.addField_SFFloat( ctx, "cutOffAngle", Math.PI / 2.0 );
 
             /**
              *

--- a/src/nodes/Lighting/SpotLight.js
+++ b/src/nodes/Lighting/SpotLight.js
@@ -86,11 +86,11 @@ x3dom.registerNodeType(
              * @var {x3dom.fields.SFFloat} beamWidth
              * @range [0, pi/2]
              * @memberof x3dom.nodeTypes.SpotLight
-             * @initvalue 1.5707963
+             * @initvalue pi/2
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "beamWidth", 1.5707963 );
+            this.addField_SFFloat( ctx, "beamWidth", Math.PI/2.0 );
 
             /**
              * The cutOffAngle field specifies the outer bound of the solid angle. The light source does not emit light outside of this solid angle.
@@ -99,11 +99,11 @@ x3dom.registerNodeType(
              * @range [0, pi/2]
              * @var {x3dom.fields.SFFloat} cutOffAngle
              * @memberof x3dom.nodeTypes.SpotLight
-             * @initvalue 1.5707963
+             * @initvalue pi/2
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "cutOffAngle", 1.5707963 );
+            this.addField_SFFloat( ctx, "cutOffAngle", Math.PI/2.0 );
 
             /**
              *

--- a/src/nodes/Navigation/X3DViewpointNode.js
+++ b/src/nodes/Navigation/X3DViewpointNode.js
@@ -97,7 +97,7 @@ x3dom.registerNodeType(
 
             getFieldOfView : function ()
             {
-                return 1.57079633;
+                return Math.PI/2.0;
             },
 
             /**

--- a/src/nodes/Navigation/X3DViewpointNode.js
+++ b/src/nodes/Navigation/X3DViewpointNode.js
@@ -97,7 +97,7 @@ x3dom.registerNodeType(
 
             getFieldOfView : function ()
             {
-                return Math.PI/2.0;
+                return Math.PI / 2.0;
             },
 
             /**

--- a/src/util/VRControllerManager.js
+++ b/src/util/VRControllerManager.js
@@ -128,7 +128,7 @@ x3dom.VRControllerManager.prototype.fit = function ( viewarea, vrDisplay )
 
     var aspect =  Math.min( viewarea._width / viewarea._height, 1 );
 
-    var tanfov2 = Math.tan( 1.57 / 2.0 );
+    var tanfov2 = Math.tan( Math.PI/4.0 );
     var dist = bsr / tanfov2 / aspect;
 
     viewarea._movement = viewDir.multiply( -dist );

--- a/src/util/VRControllerManager.js
+++ b/src/util/VRControllerManager.js
@@ -128,7 +128,7 @@ x3dom.VRControllerManager.prototype.fit = function ( viewarea, vrDisplay )
 
     var aspect =  Math.min( viewarea._width / viewarea._height, 1 );
 
-    var tanfov2 = Math.tan( Math.PI/4.0 );
+    var tanfov2 = Math.tan( Math.PI / 4.0 );
     var dist = bsr / tanfov2 / aspect;
 
     viewarea._movement = viewDir.multiply( -dist );

--- a/src/util/VRControllerManager.js
+++ b/src/util/VRControllerManager.js
@@ -128,7 +128,7 @@ x3dom.VRControllerManager.prototype.fit = function ( viewarea, vrDisplay )
 
     var aspect =  Math.min( viewarea._width / viewarea._height, 1 );
 
-    var tanfov2 = Math.tan( Math.PI / 4.0 );
+    var tanfov2 = Math.tan( 0.5 * Math.PI / 2.0 );
     var dist = bsr / tanfov2 / aspect;
 
     viewarea._movement = viewDir.multiply( -dist );


### PR DESCRIPTION
I'm always confused when I see 'magic' numbers in code. 
What is the meaning of `1.57`?
Does this represent 90° or approximately 90° (because high precision does not matter) or a little bit less than 90° (which might be important to avoid singularity issues)?

In the code we mostly see `Math.PI / 2` instead and sometimes `Math.PI / 2.0` (which looks better as it's a float anyway). 

Therefore I've replaced the remaining different constants `1.57`, `1.570796`, `1.5707963`, `1.57079633` by `Math.PI / 2.0` 

(Exception: in ShaderDynamic.js the constants are required for the gl command string.)

Limited test: My program is still working and it's using some of these pieces of code. However, I've no idea how to produce test cases for all changes. 
