### PR TITLE
Extend log messages

### DIFF
--- a/src/Viewarea.js
+++ b/src/Viewarea.js
@@ -1360,7 +1360,9 @@ x3dom.Viewarea.prototype.onMouseRelease = function ( x, y, buttonState, prevButt
     var navi = this._scene.getNavigationInfo();
     var navType = navi.getType();
 
-    if ( this._scene._vf.pickMode.toLowerCase() !== "box" )
+    var pickMode = this._scene._vf.pickMode.toLowerCase();
+
+    if ( pickMode !== "box" )
     {
         this.prepareEvents( x, y, prevButton, "onmouseup" );
 
@@ -1414,7 +1416,22 @@ x3dom.Viewarea.prototype.onMouseRelease = function ( x, y, buttonState, prevButt
 
             x3dom.debug.logInfo( "Hit '" + obj._xmlNode.localName + "/ " +
                 obj._DEF + "' at dist=" + line.dist.toFixed( 4 ) );
-            x3dom.debug.logInfo( "Ray hit at position " + this._pick );
+            if ( pickMode === "color" )
+            {
+                x3dom.debug.logInfo( "Ray hit color " + this._pick );
+            }
+            else if ( pickMode === "idbufid" || pickMode === "texcoord" )
+            {
+                x3dom.debug.logInfo( "Ray hit data " + this._pick );
+            }
+            else
+            { // idbuf idbuf24 box
+                x3dom.debug.logInfo( "Ray hit at position "
+                    + this._pick.x.toFixed( 4 ) + " "
+                    + this._pick.y.toFixed( 4 ) + " "
+                    + this._pick.z.toFixed( 4 )
+                );
+            }
         }
 
         var t1 = new Date().getTime() - t0;
@@ -1700,7 +1717,22 @@ x3dom.Viewarea.prototype.prepareEvents = function ( x, y, buttonState, eventType
             {  // debug
                 if ( obj._xmlNode )
                 {x3dom.debug.logInfo( "Hit \"" + obj._xmlNode.localName + "/ " + obj._DEF + "\"" );}
-                x3dom.debug.logInfo( "Ray hit at position " + this._pick );
+                if ( pickMode === "color" )
+                {
+                    x3dom.debug.logInfo( "Ray hit color " + this._pick );
+                }
+                else if ( pickMode === "idbufid" || pickMode === "texcoord" )
+                {
+                    x3dom.debug.logInfo( "Ray hit data " + this._pick );
+                }
+                else
+                { // idbuf idbuf24 box
+                    x3dom.debug.logInfo( "Ray hit at position "
+                        + this._pick.x.toFixed( 4 ) + " "
+                        + this._pick.y.toFixed( 4 ) + " "
+                        + this._pick.z.toFixed( 4 )
+                    );
+                }
             }
         }
     }

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -1049,9 +1049,9 @@ x3dom.gfx_webgl = ( function ()
 
                 if ( sky.length != colors.length )
                 {
-                    x3dom.debug.logError( "Number of background colors (" + colors.length
-                        + ") and corresponding angles (" + sky.length
-                        + ") are different!" );
+					// 
+                    x3dom.debug.logError( "Number of background colors and corresponding angles do not match.\n"
+						+ "You have to define one angle less than the count of RGB colors because the angle 0° is added automatically." );
                     var minArrayLength = ( sky.length < colors.length ) ? sky.length : colors.length;
                     sky.length = minArrayLength;
                     colors.length = minArrayLength;

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -1049,7 +1049,9 @@ x3dom.gfx_webgl = ( function ()
 
                 if ( sky.length != colors.length )
                 {
-                    x3dom.debug.logError( "Number of background colors and corresponding angles are different!" );
+                    x3dom.debug.logError( "Number of background colors (" + colors.length
+                        + ") and corresponding angles (" + sky.length
+                        + ") are different!" );
                     var minArrayLength = ( sky.length < colors.length ) ? sky.length : colors.length;
                     sky.length = minArrayLength;
                     colors.length = minArrayLength;

--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -1049,9 +1049,8 @@ x3dom.gfx_webgl = ( function ()
 
                 if ( sky.length != colors.length )
                 {
-					// 
                     x3dom.debug.logError( "Number of background colors and corresponding angles do not match.\n"
-						+ "You have to define one angle less than the count of RGB colors because the angle 0° is added automatically." );
+                        + "You have to define one angle less than the count of RGB colors because the angle 0° is added automatically." );
                     var minArrayLength = ( sky.length < colors.length ) ? sky.length : colors.length;
                     sky.length = minArrayLength;
                     colors.length = minArrayLength;

--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -1299,7 +1299,11 @@ x3dom.Utils.wrapProgram = function ( gl, program, shaderID )
         glErr = gl.getError();
         if ( glErr )
         {
-            x3dom.debug.logError( "GL-Error (on searching uniforms): " + glErr );
+            x3dom.debug.logError( "GL-Error (on searching uniforms):"
+                + " name=" + obj.name
+                + " type=" + obj.type
+                + " size=" + obj.size
+                + " Err=" + glErr );
         }
 
         loc = gl.getUniformLocation( program, obj.name );
@@ -1402,7 +1406,11 @@ x3dom.Utils.wrapProgram = function ( gl, program, shaderID )
         glErr = gl.getError();
         if ( glErr )
         {
-            x3dom.debug.logError( "GL-Error (on searching attributes): " + glErr );
+            x3dom.debug.logError( "GL-Error (on searching attributes):"
+                + " name=" + obj.name
+                + " type=" + obj.type
+                + " size=" + obj.size
+                + " Err=" + glErr );
         }
 
         loc = gl.getAttribLocation( program, obj.name );


### PR DESCRIPTION
Concerning pick mode:
"color" shows the RGB colors.
"idbuf", "idbuf24", "box" show the position.
"idbufid", "texcoord" don't show the position, therefore I decided to name it simply 'data'.

Concerning Background node:
It is not useful to show the sum count of explicit plus implicit colors or angels - the user would not recognize and understand these numbers. However, it might help to explain how to correct the data.
This condition has to be true:
(skyAngle.lenght == skyColor.length - 1) && (groundAngle.length == groundColor.length -1)