### PR TITLE
Correct axis definition "negY"

### DIFF
--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -758,7 +758,7 @@ x3dom.Runtime.prototype.showObject = function ( obj, axis )
             case "posX": n0 = new x3dom.fields.SFVec3f( 1,  0,  0 ); break;
             case "negX": n0 = new x3dom.fields.SFVec3f( -1,  0,  0 ); break;
             case "posY": n0 = new x3dom.fields.SFVec3f( 0,  1,  0 ); break;
-            case "negY": n0 = new x3dom.fields.SFVec3f( 1, -1,  0 ); break;
+            case "negY": n0 = new x3dom.fields.SFVec3f( 0, -1,  0 ); break;
             case "posZ": n0 = new x3dom.fields.SFVec3f( 0,  0,  1 ); break;
             case "negZ": n0 = new x3dom.fields.SFVec3f( 0,  0, -1 ); break;
         }


### PR DESCRIPTION
Axis  definition "negY" evaluates to ( 1, -1,  0 ) instead of ( 0, -1,  0 ).

In addition we could think about accepting axis definitions directly instead of symbolic names like "negY": In the default case of the switch statement we could check if parameter axis has type `SFVec3f` or can be resolved to this type. Well, that would be an extension of the API which requires corresponding documentation. And in this case we should do the same in `x3dom.Viewarea.prototype.showAll`.