### PR TITLE
Small documentation updates

### DIFF
--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -508,7 +508,6 @@ x3dom.Runtime.prototype.getSceneBRect = function ()
  *
  * Returns the 2d client (returns the mouse coordinates relative to the window) position [cx, cy]
  * for a given point [wx, wy, wz] in world coordinates.
- * (This is the replacement function for the deprecated function calcPagePos.)
  *
  * @param wx
  * @param wy

--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -471,7 +471,7 @@ x3dom.Runtime.prototype.getBBoxPoints = function ()
 };
 
 /**
- * Function: calcPagePos
+ * Function: getSceneBRect
  *
  * @returns The 2d rect of the scene volume
  */
@@ -508,6 +508,7 @@ x3dom.Runtime.prototype.getSceneBRect = function ()
  *
  * Returns the 2d client (returns the mouse coordinates relative to the window) position [cx, cy]
  * for a given point [wx, wy, wz] in world coordinates.
+ * (This is the replacement function for the deprecated function calcPagePos.)
  *
  * @param wx
  * @param wy

--- a/src/fields.js
+++ b/src/fields.js
@@ -420,7 +420,7 @@ x3dom.fields.SFMatrix4f.prototype.setRotate = function ( quat )
 };
 
 /**
- * Creates a new matrix from a column major string representation, with values separated by commas
+ * Creates a new matrix from a column major string representation, with values separated by commas or whitespace
  *
  * @param {String} str - string to parse
  * @returns {x3dom.fields.SFMatrix4f} the new matrix
@@ -1690,7 +1690,7 @@ x3dom.fields.SFMatrix4f.prototype.toString = function ()
 
 /**
  * Fills the values of this matrix from a string, where the entries are separated
- * by commas and given in column-major order.
+ * by commas or whitespaces and given in column-major order.
  *
  * @param {String} str - the string representation
  */

--- a/src/fields.js
+++ b/src/fields.js
@@ -1690,7 +1690,7 @@ x3dom.fields.SFMatrix4f.prototype.toString = function ()
 
 /**
  * Fills the values of this matrix from a string, where the entries are separated
- * by commas or whitespaces and given in column-major order.
+ * by commas or whitespace, and given in column-major order.
  *
  * @param {String} str - the string representation
  */

--- a/src/nodes/EnvironmentalEffects/Background.js
+++ b/src/nodes/EnvironmentalEffects/Background.js
@@ -30,7 +30,7 @@ x3dom.registerNodeType(
             x3dom.nodeTypes.Background.superClass.call( this, ctx );
 
             /**
-             * Image shown at the back of the background cube 
+             * Image shown at the back of the background cube
              * @var {x3dom.fields.MFString} backUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -41,7 +41,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "backUrl", [] );
 
             /**
-             * Image shown at the bottom of the background cube 
+             * Image shown at the bottom of the background cube
              * @var {x3dom.fields.MFString} bottomUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -52,7 +52,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "bottomUrl", [] );
 
             /**
-             * Image shown at the front of the background cube 
+             * Image shown at the front of the background cube
              * @var {x3dom.fields.MFString} frontUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -63,7 +63,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "frontUrl", [] );
 
             /**
-             * Image shown at the left of the background cube 
+             * Image shown at the left of the background cube
              * @var {x3dom.fields.MFString} leftUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -74,7 +74,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "leftUrl", [] );
 
             /**
-             * Image shown at the right of the background cube 
+             * Image shown at the right of the background cube
              * @var {x3dom.fields.MFString} rightUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -85,7 +85,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "rightUrl", [] );
 
             /**
-             * Image shown at the top of the background cube 
+             * Image shown at the top of the background cube
              * @var {x3dom.fields.MFString} topUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []

--- a/src/nodes/EnvironmentalEffects/Background.js
+++ b/src/nodes/EnvironmentalEffects/Background.js
@@ -96,7 +96,7 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "topUrl", [] );
 
             /**
-             * Scale images of the background cube (### verification needed as I didn't found any example running trought the corresponding coding)
+             * Scale images of the background cube
              * @var {x3dom.fields.MFString} scaling
              * @memberof x3dom.nodeTypes.Background
              * @initvalue false

--- a/src/nodes/EnvironmentalEffects/Background.js
+++ b/src/nodes/EnvironmentalEffects/Background.js
@@ -30,7 +30,7 @@ x3dom.registerNodeType(
             x3dom.nodeTypes.Background.superClass.call( this, ctx );
 
             /**
-             *
+             * Image shown at the back of the background cube 
              * @var {x3dom.fields.MFString} backUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
@@ -41,65 +41,65 @@ x3dom.registerNodeType(
             this.addField_MFString( ctx, "backUrl", [] );
 
             /**
-             *
+             * Image shown at the bottom of the background cube 
              * @var {x3dom.fields.MFString} bottomUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
              * @range [URI]
-             * @field x3dom
+             * @field x3d
              * @instance
              */
             this.addField_MFString( ctx, "bottomUrl", [] );
 
             /**
-             *
+             * Image shown at the front of the background cube 
              * @var {x3dom.fields.MFString} frontUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
              * @range [URI]
-             * @field x3dom
+             * @field x3d
              * @instance
              */
             this.addField_MFString( ctx, "frontUrl", [] );
 
             /**
-             *
+             * Image shown at the left of the background cube 
              * @var {x3dom.fields.MFString} leftUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
              * @range [URI]
-             * @field x3dom
+             * @field x3d
              * @instance
              */
             this.addField_MFString( ctx, "leftUrl", [] );
 
             /**
-             *
+             * Image shown at the right of the background cube 
              * @var {x3dom.fields.MFString} rightUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
              * @range [URI]
-             * @field x3dom
+             * @field x3d
              * @instance
              */
             this.addField_MFString( ctx, "rightUrl", [] );
 
             /**
-             *
+             * Image shown at the top of the background cube 
              * @var {x3dom.fields.MFString} topUrl
              * @memberof x3dom.nodeTypes.Background
              * @initvalue []
              * @range [URI]
-             * @field x3dom
+             * @field x3d
              * @instance
              */
             this.addField_MFString( ctx, "topUrl", [] );
 
             /**
-             *
+             * Scale images of the background cube (### verification needed as I didn't found any example running trought the corresponding coding)
              * @var {x3dom.fields.MFString} scaling
              * @memberof x3dom.nodeTypes.Background
-             * @initvalue []
+             * @initvalue false
              * @field x3dom
              * @instance
              */

--- a/src/nodes/EnvironmentalEffects/X3DBackgroundNode.js
+++ b/src/nodes/EnvironmentalEffects/X3DBackgroundNode.js
@@ -41,6 +41,8 @@ x3dom.registerNodeType(
 
             /**
              * Color of the ground
+             * Multiple color values are possible.
+             * You have to define 1 color more that you define ground angles.
              * @var {x3dom.fields.MFColor} groundColor
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue (0,0,0)
@@ -52,6 +54,7 @@ x3dom.registerNodeType(
 
             /**
              * Angle of the ground
+             * Multiple values are possible
              * @var {x3dom.fields.MFFloat} groundAngle
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue []
@@ -63,6 +66,8 @@ x3dom.registerNodeType(
 
             /**
              * Color of the sky
+             * Multiple color values are possible.
+             * You have to define 1 color more that you define sky angles.
              * @var {x3dom.fields.MFColor} skyColor
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue (0,0,0)
@@ -74,6 +79,7 @@ x3dom.registerNodeType(
 
             /**
              * Angle of the sky
+             * Multiple values are possible
              * @var {x3dom.fields.MFFloat} skyAngle
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue []

--- a/src/nodes/EnvironmentalEffects/X3DBackgroundNode.js
+++ b/src/nodes/EnvironmentalEffects/X3DBackgroundNode.js
@@ -42,7 +42,7 @@ x3dom.registerNodeType(
             /**
              * Color of the ground
              * Multiple color values are possible.
-             * You have to define 1 color more that you define ground angles.
+             * Define 1 more color than the number of ground angles.
              * @var {x3dom.fields.MFColor} groundColor
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue (0,0,0)
@@ -67,7 +67,7 @@ x3dom.registerNodeType(
             /**
              * Color of the sky
              * Multiple color values are possible.
-             * You have to define 1 color more that you define sky angles.
+             * Define 1 more color than the number of sky angles.
              * @var {x3dom.fields.MFColor} skyColor
              * @memberof x3dom.nodeTypes.X3DBackgroundNode
              * @initvalue (0,0,0)

--- a/src/nodes/Geometry3D/Sphere.js
+++ b/src/nodes/Geometry3D/Sphere.js
@@ -27,14 +27,14 @@ x3dom.registerNodeType(
         {
             x3dom.nodeTypes.Sphere.superClass.call( this, ctx );
 
-            // sky box background creates sphere with r = 10000
+            // sky box background creates sphere with r = 1000
 
             /**
              * The radius field specifies the radius of the sphere.
              * @var {x3dom.fields.SFFloat} radius
              * @range [0, inf]
              * @memberof x3dom.nodeTypes.Sphere
-             * @initvalue ctx?1:10000
+             * @initvalue ctx?1:1000
              * @field x3d
              * @instance
              */

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -62,6 +62,14 @@ x3dom.registerNodeType(
 
             /**
              * Specifies the view angle and height for helicopter mode and min/max rotation angle for turntable in ]0, PI[, starting from +y (0) down to -y (PI)
+             * [0] helicopter vertical view angle theta
+             * [1] helicopter height
+             * [2] min vertical view angle theta
+             * [3] max vertical view angle theta
+             * [4] turntable min orbit rotation angle phi (yaw)  (### needs verification)
+             * [5] turntable max orbit rotation angle phi (yaw)  (### needs verification)
+             * [6] turntable min zoom amount                     (### needs verification)
+             * [7] turntable max zoom amount                     (### needs verification)
              * @var {x3dom.fields.MFFloat} typeParams
              * @memberof x3dom.nodeTypes.NavigationInfo
              * @initvalue [-0.4,60,0.05,2.8]

--- a/src/nodes/Navigation/NavigationInfo.js
+++ b/src/nodes/Navigation/NavigationInfo.js
@@ -62,14 +62,6 @@ x3dom.registerNodeType(
 
             /**
              * Specifies the view angle and height for helicopter mode and min/max rotation angle for turntable in ]0, PI[, starting from +y (0) down to -y (PI)
-             * [0] helicopter vertical view angle theta
-             * [1] helicopter height
-             * [2] min vertical view angle theta
-             * [3] max vertical view angle theta
-             * [4] turntable min orbit rotation angle phi (yaw)  (### needs verification)
-             * [5] turntable max orbit rotation angle phi (yaw)  (### needs verification)
-             * [6] turntable min zoom amount                     (### needs verification)
-             * [7] turntable max zoom amount                     (### needs verification)
              * @var {x3dom.fields.MFFloat} typeParams
              * @memberof x3dom.nodeTypes.NavigationInfo
              * @initvalue [-0.4,60,0.05,2.8]


### PR DESCRIPTION
While analyzing x3dom, i.e. about defining background cube pictures and about copying ideas from the helicopter mode for my own navigation mode, I made some comments into the documentation which might be useful for the master, too.

- The background cube is defined in x3d, it's not added by x3dom. 
see 
https://www.web3d.org/documents/specifications/19775-1/V3.3/Part01/components/enveffects.html#Background
- I didn't found a way to use the `scaling` attribute of the `Background` note but a least I can state, that's a boolean attribute.
see `gfx_webgl.js`
`if ( bgnd._vf.scaling && bgnd._webgl.texture.ready )` ...

- The array attribute `typeParams`  of the `NavigationInfo` note has up to 7 values.

side remarks:
The scaling of the background cube pictures seemed to have changed between versions but I didn't found the reason yet (otherwise I would try to offer a PR for it): With the current version of x3dom you see a heavily zoomed-in picture which looks quite bad. It's difficult to demonstrate it in my program but you can see the same effect here: http://antorof.github.io/SolarSystem-X3Dom/ 
The background should look like this:
http://antorof.github.io/SolarSystem-X3Dom/sistemasolar/resources/space_BK.jpg
http://antorof.github.io/SolarSystem-X3Dom/sistemasolar/resources/space_LF.jpg
etc.
