### PR TITLE
Background Cube

### DIFF
--- a/src/gfx_webgl.js
+++ b/src/gfx_webgl.js
@@ -936,17 +936,22 @@ x3dom.gfx_webgl = ( function ()
 
                 bgnd._webgl.primType = gl.TRIANGLES;
 
+                var _bgnd      = null, //### separate variables to ease debugging
+                    scale      = true,
+                    genMipMaps = false,
+                    flipY      = false; // relevant for DDS only
+
                 if ( url[ 0 ].indexOf( ".dds" ) != -1 )
                 {
                     bgnd._webgl.shader = this.cache.getShader( gl, x3dom.shader.BACKGROUND_CUBETEXTURE_DDS );
-                    bgnd._webgl.texture = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, [ url[ 0 ] ],
-                        false, bgnd._vf.crossOrigin, true, false, false );
+                    //bgnd._webgl.texture = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, [ url[ 0 ] ], false, bgnd._vf.crossOrigin, true,  false,      false );
+                    bgnd._webgl.texture   = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, [ url[ 0 ] ], _bgnd, bgnd._vf.crossOrigin, scale, genMipMaps, flipY );
                 }
                 else
                 {
-                    bgnd._webgl.shader = this.cache.getShader( gl, x3dom.shader.BACKGROUND_CUBETEXTURE_DDS );
-                    bgnd._webgl.texture = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, url,
-                        false, bgnd._vf.crossOrigin, true, false );
+                    bgnd._webgl.shader = this.cache.getShader( gl, x3dom.shader.BACKGROUND_CUBETEXTURE ); //### This is the essential part of the correction
+                    //bgnd._webgl.texture = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, url,          false, bgnd._vf.crossOrigin, true,  false             ); //### flipY is missing
+                    bgnd._webgl.texture   = x3dom.Utils.createTextureCube( gl, bgnd._nameSpace.doc, url,          _bgnd, bgnd._vf.crossOrigin, scale, genMipMaps, flipY );
                 }
             }
             else

--- a/src/nodes/Geometry3D/Sphere.js
+++ b/src/nodes/Geometry3D/Sphere.js
@@ -38,7 +38,8 @@ x3dom.registerNodeType(
              * @field x3d
              * @instance
              */
-            this.addField_SFFloat( ctx, "radius", ctx ? 1 : 1000 );
+            var radius = 1000; //### separate variable to ease debugging
+            this.addField_SFFloat( ctx, "radius", ctx ? 1 : radius ); //### The radius is irrelevant in case of the background cube: any value like 1, 2, 1000, 10000 produce the same result
 
             /**
              * Specifies the number of faces that are generated to approximate the surface of the sphere.


### PR DESCRIPTION
Background Cube images look different between x3dom 1.7.2 (good) and  1.8.1 (ugly). The reason was not, as initially suspected, the size of the generated background sphere - this size is in fact irrelevant- but because the wrong shader name `BACKGROUND_CUBETEXTURE_DDS` which is used even if you do not provide an dds file.

After replacing the shader name, the images look as expected and all images are connected correctly to fill the cube.
However, there is still one more difference: the view is flipped upside down.

So far I tested only using https://github.com/fblupi/x3d-solar-system with the original images and another background picture set.

The current commit contains some additional comments which I will remove later. 