### PR TITLE
Use alphaCutoff only in 'MASK' alphaMode as according to spec

### DIFF
--- a/src/shader/ShaderDynamic.js
+++ b/src/shader/ShaderDynamic.js
@@ -1317,10 +1317,6 @@ x3dom.shader.DynamicShader.prototype.generateFragmentShader = function ( gl, pro
         shader += "if (color.a <= alphaCutoff) discard;\n";
         shader += "color.a = 1.0;\n";
     }
-    else
-    {
-        shader += "if (color.a <= alphaCutoff) discard;\n";
-    }
 
     //Output the gamma encoded result.
     shader += "if(tonemappingOperator == 1.0) {\n";


### PR DESCRIPTION
Hi!

I'm rendering gltf meshes with transparent textures or materials and was wondering why they are not rendering until I changed the value of alphaCutoff. According to the documentation the alphaCutoff should only be used in case alphaMode is "MASK"  [1][2], but it is also used in "BLEND".

After removing the last else clause of:
https://github.com/x3dom/x3dom/blob/cdadbc1c01d3c04989c0bb7176032c90eddca466/src/shader/ShaderDynamic.js#L1310-L1324

my objects got rendered correctly. 

[1] https://doc.x3dom.org/developer/x3dom/nodeTypes/PhysicalMaterial.html
[2] https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/AlphaBlendModeTest/README.md