### PR TITLE
Remove duplicate codes

### DIFF
--- a/build/core/packages.json
+++ b/build/core/packages.json
@@ -434,10 +434,7 @@
             "UniversalJoint.js",
             "SingleAxisHingeJoint.js",
             "DoubleAxisHingeJoint.js"
-        ]
-    },
-    "AMMO":
-    {
+        ],
         "lib/":
         [
             "ammo.js"

--- a/build/src-builder.js
+++ b/build/src-builder.js
@@ -124,11 +124,11 @@ async function build()
 
     console.log( "> Write x3dom-physics.debug.js ..." );
 
-    fs.writeFileSync( DIST_FOLDER + "x3dom-physics.debug.js", HEADER + versions[ "PHYSICS" ] + versions[ "AMMO" ] );
+    fs.writeFileSync( DIST_FOLDER + "x3dom-physics.debug.js", HEADER + versions[ "PHYSICS" ] );
 
     console.log( "> Write x3dom-physics.js ..." );
 
-    fs.writeFileSync( DIST_FOLDER + "x3dom-physics.js", HEADER + versions[ "PHYSICS_MIN" ] + versions[ "AMMO" ]  );
+    fs.writeFileSync( DIST_FOLDER + "x3dom-physics.js", HEADER + versions[ "PHYSICS_MIN" ] );
 
     console.log( "> Write VERSION ..." );
 


### PR DESCRIPTION
versions[ "AMMO" ] contains versions[ "PHYSICS" ]. That makes most codes duplicated.