### PR TITLE
Slice array buffer to avoid mutating during normalization on glTF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * more accurate startTime update
   * tune PhysicalMaterial for compatible light intensity
 * Bugfixes
+  * fix for key buffer reuse in glTF animation (#1349)
   * fix Rectangle2D size updates
   * fix fitAll for OrthoViewpoint
   * fix nav. type field updates

--- a/src/util/BinaryContainerSetup.js
+++ b/src/util/BinaryContainerSetup.js
@@ -1793,7 +1793,7 @@ x3dom.BinaryContainerLoader.setupBufferInterpolator = function ( interpolator )
         var data = x3dom.BinaryContainerLoader.getArrayBufferFromType( componentType,
             arraybuffer,
             byteOffset,
-            byteLength );
+            byteLength ).slice();
 
         for ( var i = 0, n = data.length; i < n; i++ )
         {


### PR DESCRIPTION
Fix for issue #1348

Prevents repeated normalization of interpolators during glTF import if buffers share the same byte offset by slicing the array. 
